### PR TITLE
Moving framework to 92X

### DIFF
--- a/NtupleProducer/plugins/EleFiller.cc
+++ b/NtupleProducer/plugins/EleFiller.cc
@@ -183,7 +183,8 @@ EleFiller::EleFiller(const edm::ParameterSet& iConfig) :
 
 
   // Output collection
-  auto_ptr<pat::ElectronCollection> result( new pat::ElectronCollection() );
+  //auto_ptr<pat::ElectronCollection> result( new pat::ElectronCollection() );
+  std::unique_ptr<pat::ElectronCollection> result( new pat::ElectronCollection() );
 
   //unsigned int i=0;
   //for (unsigned int i = 0; i< electronHandle->size(); ++i){
@@ -351,7 +352,8 @@ EleFiller::EleFiller(const edm::ParameterSet& iConfig) :
     result->push_back(l);
     //i++;
   }
-  iEvent.put(result);
+  //iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 

--- a/NtupleProducer/plugins/ExtractMETSignificance.cc
+++ b/NtupleProducer/plugins/ExtractMETSignificance.cc
@@ -56,16 +56,20 @@ void ExtractMETSignificance::produce(edm::Event& iEvent, const edm::EventSetup& 
     const reco::METCovMatrix cov = patMET.getSignificanceMatrix();
     double sig = patMET.significance();
 
-    std::auto_ptr<double> significance (new double);
-    (*significance) = sig;
+    //std::auto_ptr<double> significance (new double);
+    std::unique_ptr<double> significance (new double);
+	(*significance) = sig;
 
-    std::auto_ptr<math::Error<2>::type> covPtr(new math::Error<2>::type());
-    (*covPtr)(0,0) = cov(0,0);
+    //std::auto_ptr<math::Error<2>::type> covPtr(new math::Error<2>::type());
+	std::unique_ptr<math::Error<2>::type> covPtr(new math::Error<2>::type());
+	(*covPtr)(0,0) = cov(0,0);
     (*covPtr)(1,0) = cov(1,0);
     (*covPtr)(1,1) = cov(1,1);
 
-    iEvent.put( covPtr, "METCovariance" );
-    iEvent.put( significance, "METSignificance" );
+    //iEvent.put( covPtr, "METCovariance" );
+    //iEvent.put( significance, "METSignificance" );
+	iEvent.put( std::move(covPtr), "METCovariance" );
+	iEvent.put( std::move(significance), "METSignificance" );
 }
 
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/NtupleProducer/plugins/GenFiller.cc
+++ b/NtupleProducer/plugins/GenFiller.cc
@@ -71,8 +71,9 @@ void GenFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     tauHadcandsMothers_.clear();
     
     // output collection
-    auto_ptr<pat::GenericParticleCollection> result( new pat::GenericParticleCollection );
-    
+    //auto_ptr<pat::GenericParticleCollection> result( new pat::GenericParticleCollection );
+	std::unique_ptr<pat::GenericParticleCollection> result( new pat::GenericParticleCollection );
+	
     unsigned int Ngen = genHandle->size();
 
     // fill vector of interesting Candidate* object, also used later for indexes
@@ -293,7 +294,8 @@ void GenFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         result->push_back (tauH);
 	result->push_back (tauH_neutral);
     }        
-    iEvent.put(result);
+    //iEvent.put(result);
+	iEvent.put(std::move(result));
 }
 
 // set of requirement(s) defining which particle must be saved

--- a/NtupleProducer/plugins/LeptonPhotonMatcher.cc
+++ b/NtupleProducer/plugins/LeptonPhotonMatcher.cc
@@ -93,8 +93,10 @@ LeptonPhotonMatcher::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 
   // Output collections
-  auto_ptr<pat::MuonCollection> resultMu( new pat::MuonCollection() );
-  auto_ptr<pat::ElectronCollection> resultEle( new pat::ElectronCollection() );
+  //auto_ptr<pat::MuonCollection> resultMu( new pat::MuonCollection() );
+  //auto_ptr<pat::ElectronCollection> resultEle( new pat::ElectronCollection() );
+  std::unique_ptr<pat::MuonCollection> resultMu( new pat::MuonCollection() );
+  std::unique_ptr<pat::ElectronCollection> resultEle( new pat::ElectronCollection() );
 
   // Associate a vector of Ptr<Photon> to lepton pointers
   typedef map<const reco::Candidate*, PhotonPtrVector> PhotonLepMap;
@@ -217,8 +219,10 @@ LeptonPhotonMatcher::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   }
   
   //Put the result in the event
-  iEvent.put(resultMu,"muons");
-  iEvent.put(resultEle,"electrons");
+  //iEvent.put(resultMu,"muons");
+  //iEvent.put(resultEle,"electrons");
+  iEvent.put(std::move(resultMu),"muons");
+  iEvent.put(std::move(resultEle),"electrons");
 }
 
 

--- a/NtupleProducer/plugins/MergeTauCollections.cc
+++ b/NtupleProducer/plugins/MergeTauCollections.cc
@@ -62,7 +62,8 @@ void MergeTauCollections::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.getByToken(theCandidateTag, tauHandle);
 
   // Output collection
-  auto_ptr<pat::TauCollection> result( new pat::TauCollection() );
+  //auto_ptr<pat::TauCollection> result( new pat::TauCollection() );
+  std::unique_ptr<pat::TauCollection> result( new pat::TauCollection() );
 
   edm::Handle<pat::TauCollection> tauHandleTauUp;
   iEvent.getByToken(theCandidateTagTauUp, tauHandleTauUp);
@@ -123,8 +124,8 @@ void MergeTauCollections::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     result->push_back(l_Nominal);
   }
 
-  iEvent.put(result);
-
+  //iEvent.put(result);
+  iEvent.put(std::move(result));
 }
  
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/NtupleProducer/plugins/MuFiller.cc
+++ b/NtupleProducer/plugins/MuFiller.cc
@@ -110,7 +110,8 @@ MuFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   //iEvent.getByLabel("offlineSlimmedPrimaryVertices",vertexs);
 
   // Output collection
-  auto_ptr<pat::MuonCollection> result( new pat::MuonCollection() );
+  //auto_ptr<pat::MuonCollection> result( new pat::MuonCollection() );
+  std::unique_ptr<pat::MuonCollection> result( new pat::MuonCollection() );
 
   for (unsigned int i = 0; i< muonHandle->size(); ++i){
     //---Clone the pat::Muon
@@ -278,7 +279,8 @@ MuFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     
     result->push_back(l);
   }
-  iEvent.put(result);
+  //iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/NtupleProducer/plugins/PairUnpacker.cc
+++ b/NtupleProducer/plugins/PairUnpacker.cc
@@ -71,7 +71,8 @@ void PairUnpacker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    iEvent.getByLabel(_InputPairsTag, pairHandle);
    
    // output collection
-   auto_ptr<reco::CandidateCollection> result( new reco::CandidateCollection );
+   //auto_ptr<reco::CandidateCollection> result( new reco::CandidateCollection );
+   std::unique_ptr<reco::CandidateCollection> result( new reco::CandidateCollection );
 
    // if pairIndex exceeds Pair collection size, do not do anything
    if (_pairIndex < pairHandle->size() )
@@ -88,7 +89,8 @@ void PairUnpacker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
    //else cout << "Unpacked nothing, returning" << endl;
 
-   iEvent.put(result);   
+   //iEvent.put(result);
+   iEvent.put(std::move(result));
 }
 
 

--- a/NtupleProducer/plugins/SVfitByPass.cc
+++ b/NtupleProducer/plugins/SVfitByPass.cc
@@ -87,7 +87,8 @@ void SVfitBypass::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   unsigned int elNumber = pairHandle->size();
   
     // Output collection
-  auto_ptr<pat::CompositeCandidateCollection> result( new pat::CompositeCandidateCollection );
+  //auto_ptr<pat::CompositeCandidateCollection> result( new pat::CompositeCandidateCollection );
+  std::unique_ptr<pat::CompositeCandidateCollection> result( new pat::CompositeCandidateCollection );
 
   // get event pat MET to be saved in output
   double METx = 0.;
@@ -171,7 +172,8 @@ void SVfitBypass::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     result->push_back(pair);
   }
-  iEvent.put(result);
+  //iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/NtupleProducer/plugins/SVfitInterface.cc
+++ b/NtupleProducer/plugins/SVfitInterface.cc
@@ -434,27 +434,17 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if ( algo.isValidSolution() )
       {
         SVfitMass = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getMass(); // full mass of tau lepton pair in units of GeV
-		SVpt      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPt();
-		SVeta     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getEta();
-		SVphi     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPhi();
-		SVptUnc   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPtUncert();
-		SVetaUnc  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getEtaUncert();
-		SVphiUnc  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPhiUncert();
-		//SVMETRho  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->;
-		//SVMETPhi  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->;
-		SVfitTransverseMass = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getTransverseMass();
-
-		/*SVfitMass = algo.getMass(); // return value is in units of GeV
-        SVpt = algo.pt();
-        SVeta = algo.eta();
-        SVphi = algo.phi();
-        SVptUnc = algo.ptUncert();
-        SVetaUnc = algo.etaUncert();
-        SVphiUnc = algo.phiUncert();
-        SVMETRho = algo.fittedMET().Rho();
-        SVMETPhi = algo.fittedMET().Phi(); // this is NOT a vector in the transverse plane! It has eta != 0.
-        SVfitTransverseMass = algo.transverseMass();*/
-        
+        SVpt      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPt();
+        SVeta     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getEta();
+        SVphi     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPhi();
+        SVptUnc   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPtUncert();
+        SVetaUnc  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getEtaUncert();
+        SVphiUnc  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPhiUncert();
+        SVfitTransverseMass = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getTransverseMass();
+        ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > fittedDiTauSystem(SVpt, SVeta, SVphi, SVfitMass);
+        Vector fittedMET = (fittedDiTauSystem.Vect() - (algo.measuredDiTauSystem()).Vect());
+        SVMETRho = fittedMET.Rho();
+        SVMETPhi = fittedMET.Phi();
       }
       else
         SVfitMass = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)
@@ -472,27 +462,19 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         
         if ( algoTauUp.isValidSolution() )
         {    
-			SVfitMassTauUp = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getMass(); // full mass of tau lepton pair in units of GeV
-			SVptTauUp      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPt();
-			SVetaTauUp     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getEta();
-			SVphiTauUp     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPhi();
-			SVptUncTauUp   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPtUncert();
-			SVetaUncTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getEtaUncert();
-			SVphiUncTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPhiUncert();
-			//SVMETRhoTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->;
-			//SVMETPhiTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->;
-			SVfitTransverseMassTauUp = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getTransverseMass();
-			
-          /*SVfitMassTauUp = algoTauUp.getMass(); // return value is in units of GeV
-          SVptTauUp = algoTauUp.pt();
-          SVetaTauUp = algoTauUp.eta();
-          SVphiTauUp = algoTauUp.phi();
-          SVptUncTauUp = algoTauUp.ptUncert();
-          SVetaUncTauUp = algoTauUp.etaUncert();
-          SVphiUncTauUp = algoTauUp.phiUncert();
-          SVMETRhoTauUp = algoTauUp.fittedMET().Rho();
-          SVMETPhiTauUp = algoTauUp.fittedMET().Phi(); // this is NOT a vector in the transverse plane! It has eta != 0.
-          SVfitTransverseMassTauUp = algoTauUp.transverseMass();*/
+          SVfitMassTauUp = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getMass(); // full mass of tau lepton pair in units of GeV
+          SVptTauUp      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPt();
+          SVetaTauUp     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getEta();
+          SVphiTauUp     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPhi();
+          SVptUncTauUp   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPtUncert();
+          SVetaUncTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getEtaUncert();
+          SVphiUncTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPhiUncert();
+          SVfitTransverseMassTauUp = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getTransverseMass();
+
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > fittedDiTauSystemUp(SVptTauUp, SVetaTauUp, SVphiTauUp, SVfitMassTauUp);
+          Vector fittedMETUp = (fittedDiTauSystemUp.Vect() - (algoTauUp.measuredDiTauSystem()).Vect());
+          SVMETRhoTauUp = fittedMETUp.Rho();
+          SVMETPhiTauUp = fittedMETUp.Phi();
         }
         else
           SVfitMassTauUp = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)
@@ -506,27 +488,19 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
         if ( algoTauDown.isValidSolution() )
         {    
-			SVfitMassTauDown = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getMass(); // full mass of tau lepton pair in units of GeV
-			SVptTauDown      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPt();
-			SVetaTauDown     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getEta();
-			SVphiTauDown     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPhi();
-			SVptUncTauDown   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPtUncert();
-			SVetaUncTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getEtaUncert();
-			SVphiUncTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPhiUncert();
-			//SVMETRhoTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->;
-			//SVMETPhiTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->;
-			SVfitTransverseMassTauDown = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getTransverseMass();
-			
-          /*SVfitMassTauDown = algoTauDown.getMass(); // return value is in units of GeV
-          SVptTauDown = algoTauDown.pt();
-          SVetaTauDown = algoTauDown.eta();
-          SVphiTauDown = algoTauDown.phi();
-          SVptUncTauDown = algoTauDown.ptUncert();
-          SVetaUncTauDown = algoTauDown.etaUncert();
-          SVphiUncTauDown = algoTauDown.phiUncert();
-          SVMETRhoTauDown = algoTauDown.fittedMET().Rho();
-          SVMETPhiTauDown = algoTauDown.fittedMET().Phi(); // this is NOT a vector in the transverse plane! It has eta != 0.
-          SVfitTransverseMassTauDown = algoTauDown.transverseMass();*/
+          SVfitMassTauDown = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getMass(); // full mass of tau lepton pair in units of GeV
+          SVptTauDown      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPt();
+          SVetaTauDown     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getEta();
+          SVphiTauDown     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPhi();
+          SVptUncTauDown   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPtUncert();
+          SVetaUncTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getEtaUncert();
+          SVphiUncTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPhiUncert();
+          SVfitTransverseMassTauDown = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getTransverseMass();
+
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > fittedDiTauSystemDown(SVptTauDown, SVetaTauDown, SVphiTauDown, SVfitMassTauDown);
+          Vector fittedMETDown = (fittedDiTauSystemDown.Vect() - (algoTauDown.measuredDiTauSystem()).Vect());
+          SVMETRhoTauDown = fittedMETDown.Rho();
+          SVMETPhiTauDown = fittedMETDown.Phi();
         }
         else
           SVfitMassTauDown = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)

--- a/NtupleProducer/plugins/SVfitInterface.cc
+++ b/NtupleProducer/plugins/SVfitInterface.cc
@@ -181,7 +181,8 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   }
   
   // Output collection
-  auto_ptr<pat::CompositeCandidateCollection> result( new pat::CompositeCandidateCollection );
+  //auto_ptr<pat::CompositeCandidateCollection> result( new pat::CompositeCandidateCollection );
+  std::unique_ptr<pat::CompositeCandidateCollection> result( new pat::CompositeCandidateCollection );
 
   // loop on all the pairs
   for (unsigned int i = 0; i < pairNumber; ++i)
@@ -599,7 +600,8 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     result->push_back(pair);     
   }
   
-  iEvent.put(result);
+  //iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 

--- a/NtupleProducer/plugins/SVfitInterface.cc
+++ b/NtupleProducer/plugins/SVfitInterface.cc
@@ -431,8 +431,19 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       algo.integrateMarkovChain();
       
       if ( algo.isValidSolution() )
-      {    
-        SVfitMass = algo.getMass(); // return value is in units of GeV
+      {
+        SVfitMass = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getMass(); // full mass of tau lepton pair in units of GeV
+		SVpt      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPt();
+		SVeta     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getEta();
+		SVphi     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPhi();
+		SVptUnc   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPtUncert();
+		SVetaUnc  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getEtaUncert();
+		SVphiUnc  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getPhiUncert();
+		//SVMETRho  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->;
+		//SVMETPhi  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->;
+		SVfitTransverseMass = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algo.getMCQuantitiesAdapter())->getTransverseMass();
+
+		/*SVfitMass = algo.getMass(); // return value is in units of GeV
         SVpt = algo.pt();
         SVeta = algo.eta();
         SVphi = algo.phi();
@@ -441,7 +452,7 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         SVphiUnc = algo.phiUncert();
         SVMETRho = algo.fittedMET().Rho();
         SVMETPhi = algo.fittedMET().Phi(); // this is NOT a vector in the transverse plane! It has eta != 0.
-        SVfitTransverseMass = algo.transverseMass();
+        SVfitTransverseMass = algo.transverseMass();*/
         
       }
       else
@@ -460,7 +471,18 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         
         if ( algoTauUp.isValidSolution() )
         {    
-          SVfitMassTauUp = algoTauUp.getMass(); // return value is in units of GeV    
+			SVfitMassTauUp = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getMass(); // full mass of tau lepton pair in units of GeV
+			SVptTauUp      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPt();
+			SVetaTauUp     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getEta();
+			SVphiTauUp     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPhi();
+			SVptUncTauUp   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPtUncert();
+			SVetaUncTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getEtaUncert();
+			SVphiUncTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getPhiUncert();
+			//SVMETRhoTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->;
+			//SVMETPhiTauUp  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->;
+			SVfitTransverseMassTauUp = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauUp.getMCQuantitiesAdapter())->getTransverseMass();
+			
+          /*SVfitMassTauUp = algoTauUp.getMass(); // return value is in units of GeV
           SVptTauUp = algoTauUp.pt();
           SVetaTauUp = algoTauUp.eta();
           SVphiTauUp = algoTauUp.phi();
@@ -469,7 +491,7 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
           SVphiUncTauUp = algoTauUp.phiUncert();
           SVMETRhoTauUp = algoTauUp.fittedMET().Rho();
           SVMETPhiTauUp = algoTauUp.fittedMET().Phi(); // this is NOT a vector in the transverse plane! It has eta != 0.
-          SVfitTransverseMassTauUp = algoTauUp.transverseMass();
+          SVfitTransverseMassTauUp = algoTauUp.transverseMass();*/
         }
         else
           SVfitMassTauUp = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)
@@ -483,7 +505,18 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
         if ( algoTauDown.isValidSolution() )
         {    
-          SVfitMassTauDown = algoTauDown.getMass(); // return value is in units of GeV    
+			SVfitMassTauDown = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getMass(); // full mass of tau lepton pair in units of GeV
+			SVptTauDown      = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPt();
+			SVetaTauDown     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getEta();
+			SVphiTauDown     = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPhi();
+			SVptUncTauDown   = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPtUncert();
+			SVetaUncTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getEtaUncert();
+			SVphiUncTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getPhiUncert();
+			//SVMETRhoTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->;
+			//SVMETPhiTauDown  = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->;
+			SVfitTransverseMassTauDown = static_cast<svFitStandalone::MCPtEtaPhiMassAdapter*>(algoTauDown.getMCQuantitiesAdapter())->getTransverseMass();
+			
+          /*SVfitMassTauDown = algoTauDown.getMass(); // return value is in units of GeV
           SVptTauDown = algoTauDown.pt();
           SVetaTauDown = algoTauDown.eta();
           SVphiTauDown = algoTauDown.phi();
@@ -492,7 +525,7 @@ void SVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
           SVphiUncTauDown = algoTauDown.phiUncert();
           SVMETRhoTauDown = algoTauDown.fittedMET().Rho();
           SVMETPhiTauDown = algoTauDown.fittedMET().Phi(); // this is NOT a vector in the transverse plane! It has eta != 0.
-          SVfitTransverseMassTauDown = algoTauDown.transverseMass();
+          SVfitTransverseMassTauDown = algoTauDown.transverseMass();*/
         }
         else
           SVfitMassTauDown = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)

--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -173,7 +173,8 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken(theVtxTag, vertexs);
 
   // Output collection
-  auto_ptr<pat::TauCollection> result( new pat::TauCollection() );
+  //auto_ptr<pat::TauCollection> result( new pat::TauCollection() );
+  std::unique_ptr<pat::TauCollection> result( new pat::TauCollection() );
 
   for (unsigned int itau = 0; itau < tauHandle->size(); ++itau){
     //---Clone the pat::Tau
@@ -447,7 +448,8 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     
     result->push_back(l);
   }
-  iEvent.put(result);
+  //iEvent.put(result);
+  iEvent.put(std::move(result));
 }
 
 

--- a/NtupleProducer/plugins/ZrecoilCorrectionProducer.cc
+++ b/NtupleProducer/plugins/ZrecoilCorrectionProducer.cc
@@ -84,7 +84,8 @@ ZrecoilCorrectionProducer::~ZrecoilCorrectionProducer()
 
 void ZrecoilCorrectionProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 {  
-  std::auto_ptr<pat::METCollection> result(new pat::METCollection());
+  //std::auto_ptr<pat::METCollection> result(new pat::METCollection());
+  std::unique_ptr<pat::METCollection> result(new pat::METCollection());
 
   // retrieve gen info
   edm::Handle<reco::GenParticleCollection> genParticles;
@@ -174,7 +175,8 @@ void ZrecoilCorrectionProducer::produce(edm::Event& evt, const edm::EventSetup& 
     result->push_back(corrMEt);
   }
 
-  evt.put(result);
+  //evt.put(result);
+  evt.put(std::move(result));
 }
 
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/NtupleProducer/plugins/bFiller.cc
+++ b/NtupleProducer/plugins/bFiller.cc
@@ -105,7 +105,8 @@ void bFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.getByToken(theCandidateTag, genHandle);
 
   // Output collection
-  auto_ptr<pat::GenericParticleCollection> result( new pat::GenericParticleCollection() );
+  //auto_ptr<pat::GenericParticleCollection> result( new pat::GenericParticleCollection() );
+  std::unique_ptr<pat::GenericParticleCollection> result( new pat::GenericParticleCollection() );
   //  printf("size %d\n",genHandle->size());
   //for(GenParticleCollection::const_iterator genp = genHandle->begin();genp != genHandle->end(); ++ genp ) {  // loop over GEN particles
   for (unsigned int i = 0; i< genHandle->size(); ++i){
@@ -183,7 +184,8 @@ void bFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     }
 
   }//end isb
-  iEvent.put(result);
+  //iEvent.put(result);
+  iEvent.put(std::move(result));
 }//end loop over genParticles
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/NtupleProducer/python/HiggsTauTauProducer_92X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_92X.py
@@ -1,0 +1,880 @@
+import FWCore.ParameterSet.Config as cms
+execfile(PyFilePath+"python/triggers_92X.py") # contains the list of triggers and filters
+
+process = cms.Process("TEST")
+
+#set this cut in the cfg file
+try: APPLYELECORR
+except NameError:
+    APPLYELECORR="None"
+ELECORRTYPE=APPLYELECORR
+try: IsMC
+except NameError:
+    IsMC=True
+try: doCPVariables
+except NameError:
+    doCPVariables=True       
+try: LEPTON_SETUP
+except NameError:
+    LEPTON_SETUP=2012
+try: APPLYFSR
+except NameError:
+    APPLYFSR=False
+try: BUILDONLYOS
+except NameError:
+    BUILDONLYOS=False
+try: Is25ns
+except NameError:
+    Is25ns=True
+
+try: USE_NOHFMET
+except NameError:
+    USE_NOHFMET=False
+
+PFMetName = "slimmedMETs"
+if USE_NOHFMET: PFMetName = "slimmedMETsNoHF"
+
+try: APPLYMETCORR
+except NameError:
+    APPLYMETCORR=True
+
+try: HLTProcessName
+except NameError:
+    HLTProcessName='HLT'
+
+### ----------------------------------------------------------------------
+### Set the GT
+### ----------------------------------------------------------------------
+from Configuration.AlCa.autoCond import autoCond
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")    
+#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+if IsMC:
+    process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_TrancheIV_v6' # FIXME !!!!!!!!
+else :
+    # process.GlobalTag.globaltag = '80X_dataRun2_Prompt_ICHEP16JEC_v0' # ICHEP            # FIXME !!!!!!!!
+    process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v7' # Run B-G                # FIXME !!!!!!!!
+    # process.GlobalTag.globaltag = '80X_dataRun2_Prompt_v16' # Run H                      # FIXME !!!!!!!!
+print process.GlobalTag.globaltag
+
+nanosec="25"
+if not Is25ns: nanosec="50"
+
+METfiltersProcess = "PAT" if IsMC else "RECO" # NB! this is not guaranteed to be true! the following is valid on 2015 Run C + Run D data. Check:
+# NB: for MET filters, use PAT or RECO depending if the miniAOD was generated simultaneously with RECO or in a separated step
+# https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016#ETmiss_filters
+
+### ----------------------------------------------------------------------
+### Standard stuff
+### ----------------------------------------------------------------------
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.Services_cff")
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+#process.load("RecoMET.METFilters.python.badGlobalMuonTaggersMiniAOD_cff")
+#process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True))
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool( True ),
+    #SkipEvent = cms.untracked.vstring('ProductNotFound')
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+### ----------------------------------------------------------------------
+### Counters 
+### ----------------------------------------------------------------------
+process.nEventsTotal = cms.EDProducer("EventCountProducer")       # don't change producer name
+process.nEventsPassTrigger = cms.EDProducer("EventCountProducer") # these names are then "hard-coded" inside the ntuplizer plugin
+
+### ----------------------------------------------------------------------
+### Trigger bit Requests - filter 
+### ----------------------------------------------------------------------
+import HLTrigger.HLTfilters.hltHighLevel_cfi as hlt
+
+process.hltFilter = hlt.hltHighLevel.clone(
+    TriggerResultsTag = cms.InputTag("TriggerResults","",HLTProcessName),
+    HLTPaths = TRIGGERLIST,
+    andOr = cms.bool(True), # how to deal with multiple triggers: True (OR) accept if ANY is true, False (AND) accept if ALL are true
+    throw = cms.bool(False) #if True: throws exception if a trigger path is invalid  
+)
+
+#MC stuff
+
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+process.drawTree = cms.EDAnalyzer("ParticleTreeDrawer",
+                                   src = cms.InputTag("prunedGenParticles"),
+                                   printP4 = cms.untracked.bool(False),
+                                   printPtEtaPhi = cms.untracked.bool(False),
+                                   printVertex = cms.untracked.bool(False),
+                                   printStatus = cms.untracked.bool(True),
+                                   printIndex = cms.untracked.bool(False) )
+
+
+process.printTree = cms.EDAnalyzer("ParticleListDrawer",
+                                   maxEventsToPrint = cms.untracked.int32(-1),
+                                   printVertex = cms.untracked.bool(False),
+                                   src = cms.InputTag("prunedGenParticles")
+                                   )
+
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+                                                   calibratedPatElectrons = cms.PSet(
+                                                       initialSeed = cms.untracked.uint32(1),
+                                                       engineName = cms.untracked.string('TRandom3')
+                                                       ),
+                                                   )
+
+
+process.goodPrimaryVertices = cms.EDFilter("VertexSelector",
+  src = cms.InputTag("offlineSlimmedPrimaryVertices"),
+  cut = cms.string(PVERTEXCUT),
+  filter = cms.bool(False), # if True, rejects events . if False, produce emtpy vtx collection
+)
+
+#Re-Reco2016 fix from G. Petrucciani
+#process.load("RecoMET.METFilters.badGlobalMuonTaggersMiniAOD_cff")
+process.badGlobalMuonTagger = cms.EDFilter("BadGlobalMuonTagger",
+    muons = cms.InputTag("slimmedMuons"),
+    vtx   = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    muonPtCut = cms.double(20),
+    selectClones = cms.bool(False),
+    taggingMode = cms.bool(True),
+    verbose     = cms.untracked.bool(False)
+)
+process.cloneGlobalMuonTagger = process.badGlobalMuonTagger.clone(
+    selectClones = cms.bool(True)
+)
+
+process.removeBadAndCloneGlobalMuons = cms.EDProducer("MuonRefPruner",
+    input = cms.InputTag("slimmedMuons"),
+    toremove = cms.InputTag("badGlobalMuonTagger", "bad"),
+    toremove2 = cms.InputTag("cloneGlobalMuonTagger", "bad")
+)
+
+# process.removeCloneGlobalMuons = cms.EDProducer("MuonRefPruner",
+#     input = cms.InputTag("removeBadGlobalMuons"),
+#     toremove = cms.InputTag("cloneGlobalMuonTagger")
+# )
+
+# process.noBadGlobalMuons = cms.Sequence(~process.cloneGlobalMuonTagger + ~process.badGlobalMuonTagger)
+process.noBadGlobalMuons = cms.Sequence(process.cloneGlobalMuonTagger + process.badGlobalMuonTagger + process.removeBadAndCloneGlobalMuons) # in tagging mode, these modules return always "true"
+
+#process.softLeptons = cms.EDProducer("CandViewMerger",
+#    #src = cms.VInputTag(cms.InputTag("slimmedMuons"), cms.InputTag("slimmedElectrons"),cms.InputTag("slimmedTaus"))
+#    src = cms.VInputTag(cms.InputTag(muString), cms.InputTag(eleString),cms.InputTag(tauString))
+#)
+
+### Mu Ghost cleaning
+# process.cleanedMu = cms.EDProducer("PATMuonCleanerBySegments",
+#                                    src = cms.InputTag("cloneGlobalMuonTagger"),
+#                                    preselection = cms.string("track.isNonnull"),
+#                                    passthrough = cms.string("isGlobalMuon && numberOfMatches >= 2"),
+#                                    fractionOfSharedSegments = cms.double(0.499))
+
+
+process.bareSoftMuons = cms.EDFilter("PATMuonRefSelector",
+    src = cms.InputTag("removeBadAndCloneGlobalMuons"),
+    cut = cms.string(MUCUT)
+#    Lowering pT cuts
+#    cut = cms.string("(isGlobalMuon || (isTrackerMuon && numberOfMatches>0)) &&" +
+#                     "pt>3 && p>3.5 && abs(eta)<2.4")
+)
+
+
+
+# # MC matching. As the genParticles are no more available in cmg, we re-match with prunedGenParticles.
+# process.muonMatch = cms.EDProducer("MCMatcher", # cut on deltaR, deltaPt/Pt; pick best by deltaR
+#                                    src     = cms.InputTag("softMuons"), # RECO objects to match  
+#                                    matched = cms.InputTag("prunedGenParticles"),   # mc-truth particle collection
+#                                    mcPdgId     = cms.vint32(13), # one or more PDG ID (13 = muon); absolute values (see below)
+#                                    checkCharge = cms.bool(True), # True = require RECO and MC objects to have the same charge
+#                                    mcStatus = cms.vint32(1),     # PYTHIA status code (1 = stable, 2 = shower, 3 = hard scattering)
+#                                    maxDeltaR = cms.double(0.5),  # Minimum deltaR for the match
+#                                    maxDPtRel = cms.double(0.5),  # Minimum deltaPt/Pt for the match
+#                                    resolveAmbiguities = cms.bool(True),     # Forbid two RECO objects to match to the same GEN object
+#                                    resolveByMatchQuality = cms.bool(False), # False = just match input in order; True = pick lowest deltaR pair first
+#                                    )
+
+process.softMuons = cms.EDProducer("MuFiller",
+    src = cms.InputTag("bareSoftMuons"),
+    genCollection = cms.InputTag("prunedGenParticles"),
+    rhoCollection = cms.InputTag("fixedGridRhoFastjetAll",""),
+    vtxCollection = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    sampleType = cms.int32(LEPTON_SETUP),                     
+    setup = cms.int32(LEPTON_SETUP), # define the set of effective areas, rho corrections, etc.
+#    cut = cms.string("userFloat('SIP')<100"),
+#    cut = cms.string("userFloat('dxy')<0.5 && userFloat('dz')<1."),
+    cut = cms.string(""),
+    flags = cms.PSet(
+        ID = cms.string("userFloat('isPFMuon')" ), # PF ID
+        isGood = cms.string(MUCUT)
+    )
+)
+
+# process.muons =  cms.Sequence(process.cleanedMu + process.bareSoftMuons+ process.softMuons)
+process.muons =  cms.Sequence(process.noBadGlobalMuons + process.bareSoftMuons+ process.softMuons)    
+
+###
+### Electrons
+###
+##--- Electron regression+calibrarion must be applied after BDT is recomputed
+## NOTE patElectronsWithRegression->eleRegressionEnergy;  calibratedElectrons-> calibratedPatElectrons
+## Default: NEW ECAL regression + NEW calibration + NEW combination
+#process.load('EgammaAnalysis.ElectronTools.electronRegressionEnergyProducer_cfi')
+#process.eleRegressionEnergy.inputElectronsTag = cms.InputTag('patElectronsWithTrigger')
+#process.eleRegressionEnergy.energyRegressionType = 2 ## 1: ECAL regression w/o subclusters 2 (default): ECAL regression w/ subclusters)
+##process.eleRegressionEnergy.vertexCollection = cms.InputTag('goodPrimaryVertices')
+#process.load("EgammaAnalysis.ElectronTools.calibratedPatElectrons_cfi")
+#process.calibratedPatElectrons.correctionsType = 2 # 1 = old regression, 2 = new regression, 3 = no regression, 0 = nothing
+#process.calibratedPatElectrons.combinationType = 3
+#process.calibratedPatElectrons.lumiRatio = cms.double(1.0)
+#process.calibratedPatElectrons.isMC    = IsMC
+#process.calibratedPatElectrons.synchronization = cms.bool(False)
+#
+##if (LEPTON_SETUP == 2011):
+##   process.eleRegressionEnergy.rhoCollection = cms.InputTag('kt6PFJetsForIso:rho')
+##   if (IsMC):
+##       process.calibratedPatElectrons.inputDataset = "Fall11"
+##   else :
+##       process.calibratedPatElectrons.inputDataset = "Jan16ReReco"
+##else :
+##if (IsMC):
+#process.calibratedPatElectrons.inputDataset = "Summer12_LegacyPaper"
+##   else :
+##process.calibratedPatElectrons.inputDataset = "22Jan2013ReReco"
+
+
+# START ELECTRON CUT BASED ID SECTION
+#
+# Set up everything that is needed to compute electron IDs and
+# add the ValueMaps with ID decisions into the event data stream
+#
+
+# Load tools and function definitions
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+
+process.load("RecoEgamma.ElectronIdentification.ElectronMVAValueMapProducer_cfi")
+#process.load("RecoEgamma.ElectronIdentification.ElectronRegressionValueMapProducer_cfi")
+
+#**********************
+dataFormat = DataFormat.MiniAOD
+switchOnVIDElectronIdProducer(process, dataFormat)
+#**********************
+
+process.load("RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cfi")
+# overwrite a default parameter: for miniAOD, the collection name is a slimmed one
+process.egmGsfElectronIDs.physicsObjectSrc = cms.InputTag('slimmedElectrons')
+
+from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
+process.egmGsfElectronIDSequence = cms.Sequence(process.egmGsfElectronIDs)
+
+# Define which IDs we want to produce
+# Each of these two example IDs contains all four standard 
+# cut-based ID working points (only two WP of the PU20bx25 are actually used here).
+#my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_PHYS14_PU20bx25_V1_miniAOD_cff']
+#my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_PHYS14_PU20bx25_V2_cff','RecoEgamma.ElectronIdentification.Identification.mvaElectronID_PHYS14_PU20bx25_nonTrig_V1_cff']
+my_id_modules =[
+'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',    # both 25 and 50 ns cutbased ids produced
+'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_50ns_V1_cff',
+'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',                 # recommended for both 50 and 25 ns
+'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff', # will not be produced for 50 ns, triggering still to come
+'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_Trig_V1_cff',    # 25 ns trig
+'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_50ns_Trig_V1_cff',    # 50 ns trig
+'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff',   #Spring16
+'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff',   #Spring16 HZZ
+
+] 
+#['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_'+nanosec+'ns_V1_cff','RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff']
+#Add them to the VID producer
+for idmod in my_id_modules:
+    setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
+    
+
+#process.bareSoftElectrons = cms.EDFilter("PATElectronRefSelector",
+#   src = cms.InputTag("slimmedElectrons"),#"calibratedPatElectrons"),
+#   cut = cms.string(ELECUT)
+#   )
+
+
+process.softElectrons = cms.EDProducer("EleFiller",
+   src    = cms.InputTag("slimmedElectrons"),
+   rhoCollection = cms.InputTag("fixedGridRhoFastjetAll",""),
+   vtxCollection = cms.InputTag("offlineSlimmedPrimaryVertices"),
+   genCollection = cms.InputTag("prunedGenParticles"),
+   sampleType = cms.int32(LEPTON_SETUP),          
+   setup = cms.int32(LEPTON_SETUP), # define the set of effective areas, rho corrections, etc.
+
+   #CUT BASED ELE ID
+   #electronVetoIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-veto"),
+   #electronTightIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-tight"),
+   #electronMediumIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-medium"),
+   #electronLooseIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-loose"),
+   #electronVetoIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-veto"),
+   #electronTightIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-tight"),
+   #electronMediumIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-medium"),
+   #electronLooseIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-loose"),
+   electronVetoIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-"+nanosec+"ns-V1-standalone-veto"),
+   electronTightIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-"+nanosec+"ns-V1-standalone-tight"),
+   electronMediumIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-"+nanosec+"ns-V1-standalone-medium"),
+   electronLooseIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-"+nanosec+"ns-V1-standalone-loose"),
+
+   #MVA ELE ID (only for 25ns right now)
+   #eleMediumIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-PHYS14-PU20bx25-nonTrig-V1-wp80"),
+   #eleTightIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-PHYS14-PU20bx25-nonTrig-V1-wp90"),
+   #mvaValuesMap     = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Phys14NonTrigValues"),
+   #mvaCategoriesMap = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Phys14NonTrigCategories"),
+   #eleMediumIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp80"),
+   #eleTightIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp90"),
+   #mvaValuesMap     = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"),
+   #mvaCategoriesMap = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Categories"),
+   eleMediumIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring16-GeneralPurpose-V1-wp90"),
+   eleTightIdMap  = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring16-GeneralPurpose-V1-wp80"),
+   mvaValuesMap     = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values"),
+   mvaCategoriesMap = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Categories"),
+   HZZmvaValuesMap  = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16HZZV1Values"),
+
+
+#    cut = cms.string("userFloat('SIP')<100"),
+#   cut = cms.string("userFloat('dxy')<0.5 && userFloat('dz')<1"),
+   cut = cms.string(ELECUT),
+   flags = cms.PSet(
+        ID = cms.string("userInt('isBDT')"), # BDT MVA ID
+        isGood = cms.string("")
+        )
+   )
+
+#process.electrons = cms.Sequence(process.egmGsfElectronIDSequence * process.softElectrons)#process.bareSoftElectrons
+
+egmMod = 'egmGsfElectronIDs'
+mvaMod = 'electronMVAValueMapProducer'
+regMod = 'electronRegressionValueMapProducer'
+egmSeq = 'egmGsfElectronIDSequence'
+setattr(process,egmMod,process.egmGsfElectronIDs.clone())
+setattr(process,mvaMod,process.electronMVAValueMapProducer.clone())
+setattr(process,regMod,process.electronRegressionValueMapProducer.clone())
+setattr(process,egmSeq,cms.Sequence(getattr(process,mvaMod)*getattr(process,egmMod)*getattr(process,regMod)))
+process.electrons = cms.Sequence(getattr(process,mvaMod)*getattr(process,egmMod)*getattr(process,regMod) * process.softElectrons)#process.bareSoftElectrons
+
+# Handle special cases
+#if ELECORRTYPE == "None" :   # No correction at all. Skip correction modules.
+#    process.bareSoftElectrons.src = cms.InputTag('slimmedElectrons')#patElectronsWithTrigger')#RH
+#    process.electrons = cms.Sequence(process.bareSoftElectrons + process.softElectrons)
+#
+#elif ELECORRTYPE == "Moriond" : # Moriond corrections: OLD ECAL regression + OLD calibration + OLD combination 
+#    if (LEPTON_SETUP == 2011):
+#        process.eleRegressionEnergy.regressionInputFile = cms.string("EgammaAnalysis/ElectronTools/data/eleEnergyReg2011Weights_V1.root")
+#    else :
+#        process.eleRegressionEnergy.regressionInputFile = cms.string("EgammaAnalysis/ElectronTools/data/eleEnergyReg2012Weights_V1.root")
+#    process.eleRegressionEnergy.energyRegressionType = 1
+#    process.calibratedPatElectrons.correctionsType   = 1
+#    process.calibratedPatElectrons.combinationType   = 1
+#
+#elif ELECORRTYPE == "Paper" : # NEW ECAL regression + NO calibration + NO combination
+#    process.eleRegressionEnergy.energyRegressionType = 2
+#    process.calibratedPatElectrons.correctionsType   = 0
+#    process.calibratedPatElectrons.combinationType   = 0
+#    
+
+# process.electronMatch = cms.EDProducer("MCMatcher",       # cut on deltaR, deltaPt/Pt; pick best by deltaR
+#                                        src         = cms.InputTag("bareSoftElectrons"), # RECO objects to match
+#                                        matched     = cms.InputTag("prunedGenParticles"), # mc-truth particle collection
+#                                        mcPdgId     = cms.vint32(11),               # one or more PDG ID (11 = electron); absolute values (see below)
+#                                        checkCharge = cms.bool(True),               # True = require RECO and MC objects to have the same charge
+#                                        mcStatus    = cms.vint32(1),                # PYTHIA status code (1 = stable, 2 = shower, 3 = hard scattering)
+#                                        maxDeltaR   = cms.double(0.5),              # Minimum deltaR for the match
+#                                        maxDPtRel   = cms.double(0.5),              # Minimum deltaPt/Pt for the match
+#                                        resolveAmbiguities    = cms.bool(True),     # Forbid two RECO objects to match to the same GEN object
+#                                        resolveByMatchQuality = cms.bool(False),    # False = just match input in order; True = pick lowest deltaR pair first
+#                                        )
+
+
+### ----------------------------------------------------------------------
+### Lepton Cleaning (clean electrons collection from muons)
+### ----------------------------------------------------------------------
+
+process.cleanSoftElectrons = cms.EDProducer("PATElectronCleaner",
+    # pat electron input source
+    src = cms.InputTag("softElectrons"),
+    # preselection (any string-based cut for pat::Electron)
+    preselection = cms.string(''),
+    # overlap checking configurables
+    checkOverlaps = cms.PSet(
+        muons = cms.PSet(
+           src       = cms.InputTag("softMuons"), # Start from loose lepton def
+           algorithm = cms.string("byDeltaR"),
+           preselection        = cms.string("(isGlobalMuon || userFloat('isPFMuon'))"), #
+           deltaR              = cms.double(0.05),  
+           checkRecoComponents = cms.bool(False), # don't check if they share some AOD object ref
+           pairCut             = cms.string(""),
+           requireNoOverlaps   = cms.bool(True), # overlaps don't cause the electron to be discared
+        )
+    ),
+    # finalCut (any string-based cut for pat::Electron)
+    finalCut = cms.string(''),
+)
+
+##
+## Taus
+##
+process.bareTaus = cms.EDFilter("PATTauRefSelector",
+   src = cms.InputTag("slimmedTaus"),
+   cut = cms.string(TAUCUT)
+   )
+
+##NOT USED FOR NOW, TBD Later
+process.cleanTaus = cms.EDProducer("PATTauCleaner",
+    src = cms.InputTag("bareTaus"),
+    # preselection (any string-based cut on pat::Tau)
+    preselection = cms.string(
+            'tauID("decayModeFinding") > 0.5 &'
+            ' tauID("byLooseCombinedIsolationDeltaBetaCorr3Hits") > 0.5 &'
+            ' tauID("againstMuonTight") > 0.5 &'
+            ' tauID("againstElectronMedium") > 0.5'
+        ),
+    
+   # overlap checking configurables
+   checkOverlaps = cms.PSet(
+      muons = cms.PSet(
+          src       = cms.InputTag("cleanPatMuons"),
+          algorithm = cms.string("byDeltaR"),
+          preselection        = cms.string(""),
+          deltaR              = cms.double(0.3),
+          checkRecoComponents = cms.bool(False), # don't check if they share some AOD object ref
+          pairCut             = cms.string(""),
+          requireNoOverlaps   = cms.bool(False), # overlaps don't cause the electron to be discared
+          ),
+      electrons = cms.PSet(
+          src       = cms.InputTag("cleanPatElectrons"),
+          algorithm = cms.string("byDeltaR"),
+          preselection        = cms.string(""),
+          deltaR              = cms.double(0.3),
+          checkRecoComponents = cms.bool(False), # don't check if they share some AOD object ref
+          pairCut             = cms.string(""),
+          requireNoOverlaps   = cms.bool(False), # overlaps don't cause the electron to be discared
+          ),
+      ),
+        # finalCut (any string-based cut on pat::Tau)
+        finalCut = cms.string(' '),
+)
+
+# NominalTESCorrection=-1#in percent\
+APPLYTESCORRECTION = APPLYTESCORRECTION if IsMC else False # always false if data
+process.softTaus = cms.EDProducer("TauFiller",
+   src = cms.InputTag("bareTaus"),
+   genCollection = cms.InputTag("prunedGenParticles"),
+   vtxCollection = cms.InputTag("goodPrimaryVertices"),
+   cut = cms.string(TAUCUT),
+   discriminator = cms.string(TAUDISCRIMINATOR),
+   NominalTESCorrection = cms.double(-1), #in percent , shift of central value of TES
+   ApplyTESCentralCorr = cms.bool(APPLYTESCORRECTION),
+   # ApplyTESUpDown = cms.bool(True if IsMC else False), # no shift computation when data
+   flags = cms.PSet(
+        isGood = cms.string("")
+        )
+   )
+
+# process.softTausTauUp = process.softTaus.clone(
+#    src = cms.InputTag("bareTaus"),
+#    genCollection = cms.InputTag("prunedGenParticles"),
+#    vtxCollection = cms.InputTag("goodPrimaryVertices"),
+#    cut = cms.string(TAUCUT),
+#    NominalUpOrDown = cms.string("Up"),
+#    NominalTESCorrection = cms.double(NominalTESCorrection),    
+#    ApplyTESCorrection = cms.bool(APPLYTESCORRECTION),                        
+#    discriminator = cms.string(TAUDISCRIMINATOR),
+#    flags = cms.PSet(
+#         isGood = cms.string("")
+#         )
+#    )
+
+# process.softTausTauDown = process.softTaus.clone(
+#    src = cms.InputTag("bareTaus"),
+#    genCollection = cms.InputTag("prunedGenParticles"),
+#    vtxCollection = cms.InputTag("goodPrimaryVertices"),
+#    cut = cms.string(TAUCUT),
+#    NominalUpOrDown = cms.string("Down"),
+#    NominalTESCorrection = cms.double(NominalTESCorrection), 
+#    ApplyTESCorrection = cms.bool(APPLYTESCORRECTION),                       
+#    discriminator = cms.string(TAUDISCRIMINATOR),
+#    flags = cms.PSet(
+#         isGood = cms.string("")
+#         )
+#    )
+
+# process.tauMatch = cms.EDProducer("MCMatcher",
+#     src = cms.InputTag("softTaus"),
+#     maxDPtRel = cms.double(999.9),
+#     mcPdgId = cms.vint32(15),
+#     mcStatus = cms.vint32(2),
+#     resolveByMatchQuality = cms.bool(False),
+#     maxDeltaR = cms.double(999.9),
+#     checkCharge = cms.bool(True),
+#     resolveAmbiguities = cms.bool(True),
+#     matched = cms.InputTag("prunedGenParticles")
+#     )
+
+
+process.taus=cms.Sequence(process.bareTaus + process.softTaus)
+
+# process.tausMerged = cms.EDProducer("MergeTauCollections",
+#     src        = cms.InputTag("softTaus"),
+#     srcTauUp   = cms.InputTag("softTausTauUp"),
+#     srcTauDown = cms.InputTag("softTausTauDown")
+# )
+
+#process.tausMerged=cms.Sequence(process.softTaus + process.softTausTauUp + process.softTausTauDown + process.tausMerging)
+
+# ### ----------------------------------------------------------------------
+# ### b quarks, only from MC
+# ### ----------------------------------------------------------------------
+# process.bQuarks = cms.EDProducer("bFiller",
+#          src = cms.InputTag("prunedGenParticles"),
+#          cut = cms.string(BCUT),
+#          flags = cms.PSet(
+#             isGood = cms.string("")
+#         )
+#  )                
+# if IsMC : process.bquarks = cms.Sequence(process.bQuarks)
+# else : process.bquarks = cms.Sequence()
+
+### ----------------------------------------------------------------------
+### gen info, only from MC
+### ----------------------------------------------------------------------
+process.genInfo = cms.EDProducer("GenFiller",
+         src = cms.InputTag("prunedGenParticles"),
+         storeLightFlavAndGlu = cms.bool(True) # if True, store also udcs and gluons (first copy)
+ )                
+if IsMC : process.geninfo = cms.Sequence(process.genInfo)
+else : process.geninfo = cms.Sequence()
+
+
+### ----------------------------------------------------------------------
+### Search for FSR candidates
+### ----------------------------------------------------------------------
+process.load("UFHZZAnalysisRun2.FSRPhotons.fsrPhotons_cff")
+process.appendPhotons = cms.EDProducer("LeptonPhotonMatcher",
+    muonSrc = cms.InputTag("softMuons"),
+    electronSrc = cms.InputTag("cleanSoftElectrons"),
+    photonSrc = cms.InputTag("boostedFsrPhotons"),#cms.InputTag("cmgPhotonSel"),
+    matchFSR = cms.bool(True)
+    )
+
+process.fsrSequence = cms.Sequence(process.fsrPhotonSequence + process.appendPhotons)
+muString = "appendPhotons:muons"
+eleString = "appendPhotons:electrons"
+if not APPLYFSR : 
+    process.fsrSequence = cms.Sequence()
+    muString = "softMuons"
+    eleString = "softElectrons"
+    tauString = "softTaus"
+#Leptons
+process.softLeptons = cms.EDProducer("CandViewMerger",
+    #src = cms.VInputTag(cms.InputTag("slimmedMuons"), cms.InputTag("slimmedElectrons"),cms.InputTag("slimmedTaus"))
+    src = cms.VInputTag(cms.InputTag(muString), cms.InputTag(eleString),cms.InputTag(tauString))
+)
+
+
+#
+#Jets
+#
+
+# # add latest pileup jet ID
+# process.load("RecoJets.JetProducers.PileupJetID_cfi")
+# process.pileupJetIdUpdated = process.pileupJetId.clone(
+#   jets = cms.InputTag("slimmedJets"),
+#   inputIsCorrected = True,
+#   applyJec = True,
+#   vertexes = cms.InputTag("offlineSlimmedPrimaryVertices")
+# )
+#print process.pileupJetIdUpdated.dumpConfig()
+
+# apply new jet energy corrections
+from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+
+jecLevels = None
+if IsMC:
+    jecLevels = [ 'L1FastJet', 'L2Relative', 'L3Absolute' ]
+else:
+    jecLevels = [ 'L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual' ]
+
+updateJetCollection(
+   process,
+   jetSource = cms.InputTag('slimmedJets'),
+   labelName = 'UpdatedJEC',
+   jetCorrections = ('AK4PFchs', cms.vstring(jecLevels), 'None')
+)
+
+process.jecSequence = cms.Sequence(process.patJetCorrFactorsUpdatedJEC * process.updatedPatJetsUpdatedJEC)
+
+process.jets = cms.EDFilter("PATJetRefSelector",
+                            #src = cms.InputTag("slimmedJets"),
+                            src = cms.InputTag("updatedPatJetsUpdatedJEC"),
+                            cut = cms.string(JETCUT)
+)
+
+
+##
+## QG tagging for jets
+##
+if COMPUTEQGVAR:
+    qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
+
+    from CondCore.DBCommon.CondDBSetup_cfi import *
+    QGPoolDBESSource = cms.ESSource("PoolDBESSource",
+                                    CondDBSetup,
+                                    toGet = cms.VPSet(),
+                                    connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),
+    )
+    
+    for type in ['AK4PFchs']:
+        QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
+                    record = cms.string('QGLikelihoodRcd'),
+                    tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
+                    label  = cms.untracked.string('QGL_'+type)
+                    )))
+
+
+    process.load('RecoJets.JetProducers.QGTagger_cfi')
+    process.QGTagger.srcJets          = cms.InputTag("jets")    # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
+    process.QGTagger.jetsLabel        = cms.string('QGL_AK4PFchs')        # Other options: see https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
+    process.jetSequence = cms.Sequence(process.jets * process.QGTagger)
+
+else:
+    process.jetSequence = cms.Sequence(process.jets)
+
+
+
+
+
+##
+## Build ll candidates (here OS)
+##
+decayString="softLeptons softLeptons"
+checkcharge=False
+if BUILDONLYOS:
+    decayString="softLeptons@+ softLeptons@-"
+    checkcharge=True
+process.barellCand = cms.EDProducer("CandViewShallowCloneCombiner",
+                                    decay = cms.string(decayString),
+                                    cut = cms.string(LLCUT),
+                                    checkCharge = cms.bool(checkcharge)
+)
+
+## ----------------------------------------------------------------------
+## MVA MET
+## ----------------------------------------------------------------------
+
+process.METSequence = cms.Sequence()
+if USEPAIRMET:
+    print "Using pair MET (MVA MET)"
+    from RecoMET.METPUSubtraction.MVAMETConfiguration_cff import runMVAMET
+    runMVAMET(process, jetCollectionPF = "patJetsReapplyJEC")
+    process.MVAMET.srcLeptons = cms.VInputTag("slimmedMuons", "slimmedElectrons", "slimmedTaus")
+    process.MVAMET.requireOS = cms.bool(False)
+    process.MVAMET.permuteLeptonsWithinPlugin = cms.bool(False)
+    process.MVAMET.leptonPermutations = cms.InputTag("barellCand")
+
+    process.MVAMETInputs = cms.Sequence(
+        process.slimmedElectronsTight + process.slimmedMuonsTight + process.slimmedTausLoose + process.slimmedTausLooseCleaned + process.patJetsReapplyJECCleaned +
+        process.pfCHS + process.pfChargedPV + process.pfChargedPU + process.pfNeutrals + process.neutralInJets +
+        process.pfMETCands + process.pfTrackMETCands + process.pfNoPUMETCands + process.pfPUCorrectedMETCands + process.pfPUMETCands +
+        process.pfChargedPUMETCands + process.pfNeutralPUMETCands + process.pfNeutralPVMETCands + process.pfNeutralUnclusteredMETCands +
+        process.pfChs +
+        process.ak4PFCHSL1FastjetCorrector + process.ak4PFCHSL2RelativeCorrector + process.ak4PFCHSL3AbsoluteCorrector + process.ak4PFCHSResidualCorrector +
+        process.ak4PFCHSL1FastL2L3Corrector + process.ak4PFCHSL1FastL2L3ResidualCorrector +
+        process.tauDecayProducts + process.tauPFMET + process.tauMET + process.tausSignificance
+    )
+    for met in ["pfMET", "pfTrackMET", "pfNoPUMET", "pfPUCorrectedMET", "pfPUMET", "pfChargedPUMET", "pfNeutralPUMET", "pfNeutralPVMET", "pfNeutralUnclusteredMET"]:
+        process.MVAMETInputs += getattr(process, met)
+        process.MVAMETInputs += getattr(process, "ak4JetsFor"+met)
+        process.MVAMETInputs += getattr(process, "corr"+met)
+        process.MVAMETInputs += getattr(process, met+"T1")
+        process.MVAMETInputs += getattr(process, "pat"+met)
+        process.MVAMETInputs += getattr(process, "pat"+met+"T1")        
+
+    process.METSequence += cms.Sequence(process.MVAMETInputs + process.MVAMET)
+
+    # # python trick: loop on all pairs for pair MET computation
+    # UnpackerTemplate = cms.EDProducer("PairUnpacker",
+    #     src = cms.InputTag("barellCand")
+    # )
+
+    # MVAPairMET = []
+    # for index in range(210):
+    #     UnpackerName = "PairUnpacker%i" % index
+    #     UnpackerModule = UnpackerTemplate.clone( pairIndex = cms.int32(index) )
+    #     setattr(process, UnpackerName, UnpackerModule)   #equiv to process.<UnpackerName> = <UnpackerModule>
+    #     process.METSequence += UnpackerModule
+
+    #     MVAMETName = "patMETMVA%i" % index
+    #     MVAModule = process.MVAMET.clone( srcLeptons = cms.VInputTag (cms.InputTag(UnpackerName) ) )
+    #     setattr(process, MVAMETName, MVAModule)
+    #     process.METSequence += MVAModule
+   
+    #     MVAPairMET.append(cms.InputTag(MVAMETName, "MVAMET"))
+
+else:
+    print "Using event pfMET (same MET for all pairs)"
+
+    from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+    runMetCorAndUncFromMiniAOD(
+      process,
+      isData= (not IsMC),
+    )
+    # patch to get a standalone MET significance collection
+    process.METSignificance = cms.EDProducer ("ExtractMETSignificance",
+                                                  srcMET=cms.InputTag("slimmedMETs","","TEST")
+                                                  )
+    process.METSequence += process.fullPatMetSequence
+    process.METSequence += process.METSignificance
+
+# ## always compute met significance
+# process.load("RecoMET.METProducers.METSignificance_cfi")
+# process.load("RecoMET.METProducers.METSignificanceParams_cfi")
+# process.METSequence += cms.Sequence(process.METSignificance)
+
+## ----------------------------------------------------------------------
+## Z-recoil correction
+## ----------------------------------------------------------------------
+
+# corrMVAPairMET = []
+if IsMC and APPLYMETCORR:
+    if USEPAIRMET:
+        process.selJetsForZrecoilCorrection = cms.EDFilter("PATJetSelector",
+            src = cms.InputTag("jets"),                                      
+            cut = cms.string("pt > 30. & abs(eta) < 4.7"), 
+            filter = cms.bool(False)
+        )
+        process.corrMVAMET = cms.EDProducer("ZrecoilCorrectionProducer",                                                   
+            srcPairs = cms.InputTag("barellCand"),
+            srcMEt = cms.InputTag("MVAMET", "MVAMET"),
+            srcGenParticles = cms.InputTag("prunedGenParticles"),
+            srcJets = cms.InputTag("selJetsForZrecoilCorrection"),
+            correction = cms.string("HTT-utilities/RecoilCorrections/data/MvaMET_MG_2016BCD.root")
+        )
+        process.METSequence += process.selJetsForZrecoilCorrection        
+        process.METSequence += process.corrMVAMET
+
+    else:
+        raise ValueError("Z-recoil corrections for PFMET not implemented yet !!")
+
+
+srcMETTag = None
+if USEPAIRMET:
+  srcMETTag = cms.InputTag("corrMVAMET") if (IsMC and APPLYMETCORR) else cms.InputTag("MVAMET", "MVAMET")
+else:
+  srcMETTag = cms.InputTag(PFMetName, "", "TEST")
+
+## ----------------------------------------------------------------------
+## SV fit
+## ----------------------------------------------------------------------
+process.SVllCand = cms.EDProducer("SVfitInterface",
+                                  srcPairs   = cms.InputTag("barellCand"),
+                                  srcSig     = cms.InputTag("METSignificance", "METSignificance"),
+                                  srcCov     = cms.InputTag("METSignificance", "METCovariance"),
+                                  usePairMET = cms.bool(USEPAIRMET),
+                                  srcMET     = srcMETTag,
+                                  computeForUpDownTES = cms.bool(COMPUTEUPDOWNSVFIT if IsMC else False)
+)
+
+## ----------------------------------------------------------------------
+## SV fit BYPASS (skip SVfit, don't compute SVfit pair mass)
+## ----------------------------------------------------------------------
+process.SVbypass = cms.EDProducer ("SVfitBypass",
+                                    srcPairs   = cms.InputTag("barellCand"),
+                                    usePairMET = cms.bool(USEPAIRMET),
+                                    srcMET     = srcMETTag,
+                                    srcSig     = cms.InputTag("METSignificance", "METSignificance"),
+                                    srcCov     = cms.InputTag("METSignificance", "METCovariance")
+)
+
+
+## ----------------------------------------------------------------------
+## Ntuplizer
+## ----------------------------------------------------------------------
+process.HTauTauTree = cms.EDAnalyzer("HTauTauNtuplizer",
+                      fileName = cms.untracked.string ("CosaACaso"),
+                      applyFSR = cms.bool(APPLYFSR),
+                      IsMC = cms.bool(IsMC),
+                      doCPVariables = cms.bool(doCPVariables),               
+                      vtxCollection = cms.InputTag("offlineSlimmedPrimaryVertices"),
+                      puCollection = cms.InputTag("slimmedAddPileupInfo"),
+                      rhoCollection = cms.InputTag("fixedGridRhoFastjetAll"),
+                      rhoMiniRelIsoCollection = cms.InputTag("fixedGridRhoFastjetCentralNeutral"),
+                      PFCandCollection = cms.InputTag("packedPFCandidates"),
+                      jetCollection = cms.InputTag("jets"),
+                      #JECset = cms.untracked.string("patJetCorrFactors"),
+                      JECset = cms.untracked.string("patJetCorrFactorsUpdatedJEC"),
+                      computeQGVar = cms.bool(COMPUTEQGVAR),
+                      QGTagger = cms.InputTag("QGTagger", "qgLikelihood"),
+                      ak8jetCollection = cms.InputTag("slimmedJetsAK8"),
+                      lepCollection = cms.InputTag("softLeptons"),
+                      lheCollection = cms.InputTag("LHEEventProduct"),
+                      genCollection = cms.InputTag("generator"),
+                      genericCollection = cms.InputTag("genInfo"),
+                      genjetCollection = cms.InputTag("slimmedGenJets"),
+                      totCollection = cms.InputTag("nEventsTotal"),
+                      passCollection = cms.InputTag("nEventsPassTrigger"),
+                      lhepCollection = cms.InputTag("externalLHEProducer"),
+                      triggerResultsLabel = cms.InputTag("TriggerResults", "", HLTProcessName), #Different names for MiniAODv2 at https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD.                      
+                      triggerSet = cms.InputTag("selectedPatTrigger"),
+                      triggerList = HLTLIST,
+                      metFilters = cms.InputTag ("TriggerResults","",METfiltersProcess),
+                      PUPPImetCollection = cms.InputTag("slimmedMETsPuppi"),
+                      srcPFMETCov = cms.InputTag("METSignificance", "METCovariance"),
+                      srcPFMETSignificance = cms.InputTag("METSignificance", "METSignificance"),
+                      l1extraIsoTau = cms.InputTag("l1extraParticles", "IsoTau"),
+                      HT = cms.InputTag("externalLHEProducer"),
+                      beamSpot = cms.InputTag("offlineBeamSpot"),
+                      nBadMu = cms.InputTag("removeBadAndCloneGlobalMuons"),
+                      genLumiHeaderTag = cms.InputTag("generator")
+                      )
+if USE_NOHFMET:
+    process.HTauTauTree.metCollection = cms.InputTag("slimmedMETsNoHF")
+else: 
+    process.HTauTauTree.metCollection = cms.InputTag("slimmedMETs", "", "TEST") # use TEST so that I get the corrected one
+
+if SVFITBYPASS:
+    process.HTauTauTree.candCollection = cms.InputTag("SVbypass")
+    process.SVFit = cms.Sequence (process.SVbypass)
+
+
+else:
+    process.HTauTauTree.candCollection = cms.InputTag("SVllCand")
+    process.SVFit = cms.Sequence (process.SVllCand)
+
+#print particles gen level - DEBUG purposes
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+process.printTree = cms.EDAnalyzer("ParticleListDrawer",
+  maxEventsToPrint = cms.untracked.int32(10),
+  printVertex = cms.untracked.bool(False),
+  src = cms.InputTag("prunedGenParticles")
+)
+
+##
+## Paths
+##
+process.PVfilter = cms.Path(process.goodPrimaryVertices)
+
+# Prepare lepton collections
+process.Candidates = cms.Sequence(
+    # process.printTree         + # just for debug, print MC particles
+    process.nEventsTotal      +
+    #process.hltFilter         + 
+    process.nEventsPassTrigger+
+    process.muons             +
+    process.electrons         + process.cleanSoftElectrons +
+    process.taus              + 
+    process.fsrSequence       +
+    process.softLeptons       + process.barellCand +
+    #process.jets              +
+    process.jecSequence + process.jetSequence + #process.jets + 
+    process.METSequence       +
+    process.geninfo           +
+    process.SVFit             
+    )
+# always run ntuplizer
+process.trees = cms.EndPath(process.HTauTauTree)# + process.HTauTauTreeTauUp + process.HTauTauTreeTauDown)
+

--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -1,0 +1,363 @@
+import FWCore.ParameterSet.Config as cms
+
+## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v 
+## do not remove any other part of path name or the check will give meaningless results!
+
+## leg numbering: write the object type the two legs refer to
+## 11: electrons, 13: muons, 15: taus, 999: others/unused (e.g. leg 2 in single muon)
+##
+
+TRIGGERLIST=[]
+#list triggers and filter paths here!
+# channel: kemu=0, ketau=1,kmutau=2,ktautau=3
+HLTLIST = cms.VPSet(
+
+### === Single muon triggers
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu20_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu18L1f0L2f10QL3f20QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoTkMu20_v"),
+        path1 = cms.vstring ("hltL3fL1sMu18L1f0Tkf20QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu22_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu20L1f0L2f10QL3f22QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoTkMu22_v"),
+        path1 = cms.vstring ("hltL3fL1sMu20L1f0Tkf22QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu22_eta2p1_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sSingleMu20erL1f0L2f10QL3f22QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ), ### ok
+    cms.PSet (
+        HLT = cms.string("HLT_IsoTkMu22_eta2p1_v"),
+        path1 = cms.vstring ("hltL3fL1sMu20erL1f0Tkf22QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoTkMu24_v"),
+        path1 = cms.vstring ("hltL3fL1sMu22L1f0Tkf24QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoTkMu24_eta2p1_v"),
+        path1 = cms.vstring ("hltL3fL1sMu22erL1f0Tkf24QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoTkMu27_v"),
+        path1 = cms.vstring ("hltL3fL1sMu22Or25L1f0Tkf27QL3trkIsoFiltered0p09"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+### === Single electron triggers
+    cms.PSet (
+        HLT = cms.string("HLT_Ele25_WPTight_Gsf_v"),
+        path1 = cms.vstring ("hltEle25WPTightGsfTrackIsoFilter"), #FIXME: to check
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_Ele25_eta2p1_WPLoose_Gsf_v"),
+        path1 = cms.vstring ("hltEle25erWPLooseGsfTrackIsoFilter"), #FIXME: to check
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+         HLT = cms.string("HLT_Ele23_WPLoose_Gsf_v"),
+         path1 = cms.vstring ("hltEle23WPLooseGsfTrackIsoFilter"),
+         path2 = cms.vstring (""),
+         leg1 = cms.int32(11),
+         leg2 = cms.int32(999)
+         ),
+### === mu tauh triggers
+    cms.PSet (
+        HLT = cms.string("HLT_Ele25_eta2p1_WPTight_Gsf_v"),
+        path1 = cms.vstring ("hltEle25erWPTightGsfTrackIsoFilter"), #FIXME: to check
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_Ele27_WPTight_Gsf_v"),
+        path1 = cms.vstring ("hltEle27WPTightGsfTrackIsoFilter"), #FIXME: to check
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(999)
+        ), ### ok
+    cms.PSet (
+        HLT = cms.string("HLT_Ele27_eta2p1_WPLoose_Gsf_v"),
+        path1 = cms.vstring ("hltEle27erWPLooseGsfTrackIsoFilter"), #FIXME: to check
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_Ele27_eta2p1_WPTight_Gsf_v"),
+        path1 = cms.vstring ("hltEle27erWPTightGsfTrackIsoFilter"), #FIXME: to check
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(999)
+        ), ### ok
+### === mu tauh triggers
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu17_eta2p1_LooseIsoPFTau20_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu16erTauJet20erL1f0L2f10QL3f17QL3trkIsoFiltered0p09", "hltOverlapFilterIsoMu17LooseIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterIsoMu17LooseIsoPFTau20"),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu17_eta2p1_LooseIsoPFTau20_SingleL1_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sSingleMu16erL1f0L2f10QL3f17QL3trkIsoFiltered0p09", "hltOverlapFilterSingleIsoMu17LooseIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterSingleIsoMu17LooseIsoPFTau20"),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ), ### ok
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu19_eta2p1_LooseIsoPFTau20_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu18erTauJet20erL1f0L2f10QL3f19QL3trkIsoFiltered0p09", "hltOverlapFilterIsoMu19LooseIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterIsoMu19LooseIsoPFTau20"),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ), ### ok
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu19_eta2p1_LooseIsoPFTau20_SingleL1_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sSingleMu18erIorSingleMu20erL1f0L2f10QL3f19QL3trkIsoFiltered0p09", "hltOverlapFilterSingleIsoMu19LooseIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterSingleIsoMu19LooseIsoPFTau20"),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ), ### ok
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu21_eta2p1_LooseIsoPFTau20_SingleL1_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sSingleMu20erIorSingleMu22erL1f0L2f10QL3f21QL3trkIsoFiltered0p09", "hltOverlapFilterSingleIsoMu21LooseIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterSingleIsoMu21LooseIsoPFTau20"),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ), ### ok
+### === ele tauh triggers
+    cms.PSet (
+        HLT = cms.string("HLT_Ele22_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1_v"),
+        path1 = cms.vstring ("hltEle22WPLooseL1SingleIsoEG20erGsfTrackIsoFilter", "hltOverlapFilterSingleIsoEle22WPLooseGsfLooseIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseIso", "hltOverlapFilterSingleIsoEle22WPLooseGsfLooseIsoPFTau20"),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(15)
+        ), ### ok
+    cms.PSet (
+        HLT = cms.string("HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_v"),
+        path1 = cms.vstring ("hltEle24WPLooseL1IsoEG22erTau20erGsfTrackIsoFilter", "hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseIso", "hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau20"),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1_v"),
+        path1 = cms.vstring ("hltEle24WPLooseL1SingleIsoEG22erGsfTrackIsoFilter", "hltOverlapFilterSingleIsoEle24WPLooseGsfLooseIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseIso", "hltOverlapFilterSingleIsoEle24WPLooseGsfLooseIsoPFTau20"),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(15)
+        ), ### ok
+    cms.PSet (
+        HLT = cms.string("HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau30_v"),
+        path1 = cms.vstring ("hltEle24WPLooseL1IsoEG22erIsoTau26erGsfTrackIsoFilter", "hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau30"),
+        path2 = cms.vstring ("hltPFTau30TrackLooseIso", "hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau30"),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(15)
+        ), ### ok
+### === tauh tauh triggers
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMediumIsoPFTau32_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau32TrackPt1MediumIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau32TrackPt1MediumIsolationDz02Reg"),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau35TrackPt1MediumIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau35TrackPt1MediumIsolationDz02Reg"),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumIsolationDz02Reg"),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMediumCombinedIsoPFTau35_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau35TrackPt1MediumCombinedIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau35TrackPt1MediumCombinedIsolationDz02Reg"),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMediumCombinedIsoPFTau40_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumCombinedIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumCombinedIsolationDz02Reg"),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMediumCombinedIsoPFTau40_Trk1_eta2p1_v"),
+        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumCombinedIsolationDz02"),
+        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumCombinedIsolationDz02"),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+# ### === ele mu triggers
+     cms.PSet (
+         HLT = cms.string("HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v"),
+         path1 = cms.vstring ("hltMu17TrkIsoVVLEle12CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered17"),
+         path2 = cms.vstring ("hltMu17TrkIsoVVLEle12CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+         leg1 = cms.int32(13),
+         leg2 = cms.int32(11)
+         ),
+     cms.PSet (
+         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v"),
+         path1 = cms.vstring ("hltMu8TrkIsoVVLEle17CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
+         path2 = cms.vstring ("hltMu8TrkIsoVVLEle17CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+         leg1 = cms.int32(13),
+         leg2 = cms.int32(11)
+         ),
+    cms.PSet (
+         HLT = cms.string("HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v"),
+         path1 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered23"),
+         path2 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+         leg1 = cms.int32(13),
+         leg2 = cms.int32(11)
+         ),
+    cms.PSet (
+         HLT = cms.string("HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_DZ_v"),
+         path1 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered23"),
+         path2 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+         leg1 = cms.int32(13),
+         leg2 = cms.int32(11)
+         ),
+    cms.PSet (
+         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v"),
+         path1 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
+         path2 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+         leg1 = cms.int32(13),
+         leg2 = cms.int32(11)
+         ),
+    cms.PSet (
+         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v"),
+         path1 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
+         path2 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+         leg1 = cms.int32(13),
+         leg2 = cms.int32(11)
+         ),
+### === mu mu triggers 
+### FIXME!! MuMu and EleEle paths have not been checked in 80X and filter names are dummy
+    cms.PSet (
+        HLT = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(13)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(13)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_TripleMu_12_10_5_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(13)
+        ),
+### === ele ele triggers 
+    cms.PSet (
+        HLT = cms.string("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(11)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(11)
+        ),    
+    cms.PSet (
+        HLT = cms.string("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(13)
+        ),
+### === 3 lepton triggers 
+    cms.PSet (
+        HLT = cms.string("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(13)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(11)
+        ),
+### === single tau triggers
+    cms.PSet (
+        HLT = cms.string("HLT_VLooseIsoPFTau140_Trk50_eta2p1_v"),
+        path1 = cms.vstring ("hltPFTau140TrackPt50LooseAbsOrRelVLooseIso"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+        ),
+    )
+
+#now I create the trigger list for HLTconfig
+for i in range(len(HLTLIST)):
+    tmpl =  str(HLTLIST[i].HLT).replace('cms.string(\'','') ##CMSSW Vaffanculo
+    tmpl = tmpl.replace('\')','') ##CMSSW Vaffanculo x 2
+    TRIGGERLIST.append(tmpl)
+#print TRIGGERLIST

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -51,12 +51,17 @@ DO_ENRICHED=False # do True by default, both ntuples and enriched outputs are sa
 STORE_ENRICHEMENT_ONLY=True # When True and DO_ENRICHED=True only collection additional to MiniAOD standard are stored. They can be used to reproduce ntuples when used together with oryginal MiniAOD with two-file-solution
 # ------------------------
 
+is92X = True if 'CMSSW_9' in os.environ['CMSSW_VERSION'] else False# True to run in 92X (2017), False to run in 80X (2016) or 76X (2015)
+print "is92X: " , is92X
 is80X = True if 'CMSSW_8' in os.environ['CMSSW_VERSION'] else False# True to run in 80X (2016), False to run in 76X (2015)
 print "is80X: " , is80X
+
 ##
 ## Standard sequence
 ##
 
+if is92X:
+    execfile(PyFilePath+"python/HiggsTauTauProducer_92X.py")
 if is80X:
     execfile(PyFilePath+"python/HiggsTauTauProducer_80X.py")
 else :

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -62,7 +62,7 @@ print "is80X: " , is80X
 
 if is92X:
     execfile(PyFilePath+"python/HiggsTauTauProducer_92X.py")
-if is80X:
+elif is80X:
     execfile(PyFilePath+"python/HiggsTauTauProducer_80X.py")
 else :
     execfile(PyFilePath+"python/HiggsTauTauProducer.py")

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ git checkout HIG-16-006
 cd -
 scram b -j 4
 ```
-</details>
 
 ### Legacy Instructions (2016 data)
 ```
@@ -238,6 +237,53 @@ cd data/RecoEgamma/ElectronIdentification/data
 git checkout egm_id_80X_v1
 cd $CMSSW_BASE/src
 scram b -j 4
+```
+
+</details>
+
+### Instructions for 92X
+
+```
+cmsrel CMSSW_9_2_3_patch2
+cd CMSSW_9_2_3_patch2/src/
+cmsenv
+
+# Z-recoil corrections
+git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/RecoilCorrections
+
+git clone https://github.com/LLRCMS/LLRHiggsTauTau
+cd LLRHiggsTauTau
+git checkout master
+git remote add my-LLR https://github.com/francescobrivio/LLRHiggsTauTau.git
+git checkout 92X
+cd -
+
+git clone -n https://github.com/latinos/UserCode-sixie-Muon-MuonAnalysisTools Muon/MuonAnalysisTools
+cd Muon/MuonAnalysisTools
+git checkout master -- interface/MuonEffectiveArea.h
+cd -
+
+git clone -n https://github.com/cms-analysis/EgammaAnalysis-ElectronTools EGamma/EGammaAnalysisTools
+cd EGamma/EGammaAnalysisTools
+git checkout c0db796 -- interface/ElectronEffectiveArea.h
+cd -
+
+# FSR corrections
+git clone -n https://github.com/VBF-HZZ/UFHZZAnalysisRun2
+cd UFHZZAnalysisRun2
+git checkout master FSRPhotons
+# need to fix: - FSRPhotons/plugins/FSRPhotonProducer.cc
+#              - FSRPhotons/plugins/PhotonPFIsoCalculator.cc
+# replace 'std::auto_ptr' with 'std::unique_ptr' 
+# search for 'iEvent.put( XXXX );' and replace with 'iEvent.put( std::move(XXXX) );'
+
+# SVfit
+git clone git@github.com:veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
+cd TauAnalysis/SVfitStandalone
+git checkout HIG-16-006
+
+cd $CMSSW_BASE/src
+scram b -j 8
 ```
 
 ### Quick usage:

--- a/README.md
+++ b/README.md
@@ -152,6 +152,53 @@ scram b -j 4
 ```
 </details>
 
+### Legacy Instructions (2016 data)
+```
+cmsrel CMSSW_8_0_26_patch1
+cd CMSSW_8_0_26_patch1/src/
+cmsenv
+
+# MET Recipe
+git cms-merge-topic cms-met:METRecipe_8020 -u
+git cms-merge-topic cms-met:METRecipe_80X_part2 -u
+
+#ReReco muons fix
+git cms-merge-topic gpetruc:badMuonFilters_80X_v2
+
+# Z-recoil corrections
+git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/RecoilCorrections
+
+git clone https://github.com/LLRCMS/LLRHiggsTauTau
+cd LLRHiggsTauTau
+git checkout master
+cd -
+
+git clone -n https://github.com/latinos/UserCode-sixie-Muon-MuonAnalysisTools Muon/MuonAnalysisTools
+cd Muon/MuonAnalysisTools
+git checkout master -- interface/MuonEffectiveArea.h
+cd -
+
+git clone -n https://github.com/cms-analysis/EgammaAnalysis-ElectronTools EGamma/EGammaAnalysisTools
+cd EGamma/EGammaAnalysisTools
+git checkout c0db796 -- interface/ElectronEffectiveArea.h
+cd -
+
+# FSR corrections
+git clone -n https://github.com/VBF-HZZ/UFHZZAnalysisRun2
+cd UFHZZAnalysisRun2
+git checkout master FSRPhotons
+
+# SVfit
+git clone git@github.com:veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
+cd TauAnalysis/SVfitStandalone
+git checkout d115239192d3eb7531e213767e02ef4777b3fbfe
+
+cd $CMSSW_BASE/src
+scram b -j 8
+
+```
+
+
 ### Instructions for 8_0_25
 
 ```


### PR DESCRIPTION
These are the main changes to port the framework to 92X:

- change auto_ptr to unique_ptr
- update of SVFitInterface for compatibility with SVFit HIG-16-006
- Two files added (HiggsTauTauProducer_92X.py, triggers_92X.py), for now these are just a copy of the 80X version
- instructions to install LLRHiggsTauTau package in CMSSW_92X

This PR is up-to date with the master branch except for the last 4 commits (21 Sept 2017).
Instead of direct merging into the master branch I suggest we add a new branch '92X'.