### PR TITLE
Update code to run on miniAOD 2017

### DIFF
--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -14,344 +14,214 @@ HLTLIST = cms.VPSet(
 
 ### === Single muon triggers
     cms.PSet (
-        HLT = cms.string("HLT_IsoMu20_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sMu18L1f0L2f10QL3f20QL3trkIsoFiltered0p09"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_IsoTkMu20_v"),
-        path1 = cms.vstring ("hltL3fL1sMu18L1f0Tkf20QL3trkIsoFiltered0p09"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_IsoMu22_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sMu20L1f0L2f10QL3f22QL3trkIsoFiltered0p09"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_IsoTkMu22_v"),
-        path1 = cms.vstring ("hltL3fL1sMu20L1f0Tkf22QL3trkIsoFiltered0p09"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_IsoMu22_eta2p1_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sSingleMu20erL1f0L2f10QL3f22QL3trkIsoFiltered0p09"),
+        HLT = cms.string("HLT_IsoMu27_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"),
         path2 = cms.vstring (""),
         leg1 = cms.int32(13),
         leg2 = cms.int32(999)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu24_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p09"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
-        ), ### ok
-    cms.PSet (
-        HLT = cms.string("HLT_IsoTkMu22_eta2p1_v"),
-        path1 = cms.vstring ("hltL3fL1sMu20erL1f0Tkf22QL3trkIsoFiltered0p09"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_IsoTkMu24_v"),
-        path1 = cms.vstring ("hltL3fL1sMu22L1f0Tkf24QL3trkIsoFiltered0p09"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_IsoTkMu24_eta2p1_v"),
-        path1 = cms.vstring ("hltL3fL1sMu22erL1f0Tkf24QL3trkIsoFiltered0p09"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_IsoTkMu27_v"),
-        path1 = cms.vstring ("hltL3fL1sMu22Or25L1f0Tkf27QL3trkIsoFiltered0p09"),
+        path1 = cms.vstring ("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07"),
         path2 = cms.vstring (""),
         leg1 = cms.int32(13),
         leg2 = cms.int32(999)
         ),
 ### === Single electron triggers
     cms.PSet (
-        HLT = cms.string("HLT_Ele25_WPTight_Gsf_v"),
-        path1 = cms.vstring ("hltEle25WPTightGsfTrackIsoFilter"), #FIXME: to check
+        HLT = cms.string("HLT_Ele32_WPTight_Gsf_v"),
+        path1 = cms.vstring ("hltEle32WPTightGsfTrackIsoFilter"),
         path2 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(999)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_Ele25_eta2p1_WPLoose_Gsf_v"),
-        path1 = cms.vstring ("hltEle25erWPLooseGsfTrackIsoFilter"), #FIXME: to check
+        HLT = cms.string("HLT_Ele35_WPTight_Gsf_v"),
+        path1 = cms.vstring ("hltEle35noerWPTightGsfTrackIsoFilter"),
         path2 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(999)
         ),
-    cms.PSet (
-         HLT = cms.string("HLT_Ele23_WPLoose_Gsf_v"),
-         path1 = cms.vstring ("hltEle23WPLooseGsfTrackIsoFilter"),
-         path2 = cms.vstring (""),
-         leg1 = cms.int32(11),
-         leg2 = cms.int32(999)
-         ),
 ### === mu tauh triggers
     cms.PSet (
-        HLT = cms.string("HLT_Ele25_eta2p1_WPTight_Gsf_v"),
-        path1 = cms.vstring ("hltEle25erWPTightGsfTrackIsoFilter"), #FIXME: to check
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_Ele27_WPTight_Gsf_v"),
-        path1 = cms.vstring ("hltEle27WPTightGsfTrackIsoFilter"), #FIXME: to check
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(999)
-        ), ### ok
-    cms.PSet (
-        HLT = cms.string("HLT_Ele27_eta2p1_WPLoose_Gsf_v"),
-        path1 = cms.vstring ("hltEle27erWPLooseGsfTrackIsoFilter"), #FIXME: to check
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_Ele27_eta2p1_WPTight_Gsf_v"),
-        path1 = cms.vstring ("hltEle27erWPTightGsfTrackIsoFilter"), #FIXME: to check
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(999)
-        ), ### ok
-### === mu tauh triggers
-    cms.PSet (
-        HLT = cms.string("HLT_IsoMu17_eta2p1_LooseIsoPFTau20_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sMu16erTauJet20erL1f0L2f10QL3f17QL3trkIsoFiltered0p09", "hltOverlapFilterIsoMu17LooseIsoPFTau20"),
-        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterIsoMu17LooseIsoPFTau20"),
+        HLT = cms.string("HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
+        path2 = cms.vstring ("hltSelectedPFTau27LooseChargedIsolationAgainstMuonL1HLTMatched","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
         leg1 = cms.int32(13),
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_IsoMu17_eta2p1_LooseIsoPFTau20_SingleL1_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sSingleMu16erL1f0L2f10QL3f17QL3trkIsoFiltered0p09", "hltOverlapFilterSingleIsoMu17LooseIsoPFTau20"),
-        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterSingleIsoMu17LooseIsoPFTau20"),
+        HLT = cms.string("HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_SingleL1_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sSingleMu22erL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24LooseChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseChargedIsoAgainstMuon","hltOverlapFilterIsoMu24LooseChargedIsoPFTau20"),
         leg1 = cms.int32(13),
         leg2 = cms.int32(15)
-        ), ### ok
-    cms.PSet (
-        HLT = cms.string("HLT_IsoMu19_eta2p1_LooseIsoPFTau20_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sMu18erTauJet20erL1f0L2f10QL3f19QL3trkIsoFiltered0p09", "hltOverlapFilterIsoMu19LooseIsoPFTau20"),
-        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterIsoMu19LooseIsoPFTau20"),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
-        ), ### ok
-    cms.PSet (
-        HLT = cms.string("HLT_IsoMu19_eta2p1_LooseIsoPFTau20_SingleL1_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sSingleMu18erIorSingleMu20erL1f0L2f10QL3f19QL3trkIsoFiltered0p09", "hltOverlapFilterSingleIsoMu19LooseIsoPFTau20"),
-        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterSingleIsoMu19LooseIsoPFTau20"),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
-        ), ### ok
-    cms.PSet (
-        HLT = cms.string("HLT_IsoMu21_eta2p1_LooseIsoPFTau20_SingleL1_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sSingleMu20erIorSingleMu22erL1f0L2f10QL3f21QL3trkIsoFiltered0p09", "hltOverlapFilterSingleIsoMu21LooseIsoPFTau20"),
-        path2 = cms.vstring ("hltPFTau20TrackLooseIsoAgainstMuon", "hltOverlapFilterSingleIsoMu21LooseIsoPFTau20"),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
-        ), ### ok
+        ),
 ### === ele tauh triggers
     cms.PSet (
-        HLT = cms.string("HLT_Ele22_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1_v"),
-        path1 = cms.vstring ("hltEle22WPLooseL1SingleIsoEG20erGsfTrackIsoFilter", "hltOverlapFilterSingleIsoEle22WPLooseGsfLooseIsoPFTau20"),
-        path2 = cms.vstring ("hltPFTau20TrackLooseIso", "hltOverlapFilterSingleIsoEle22WPLooseGsfLooseIsoPFTau20"),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
-        ), ### ok
-    cms.PSet (
-        HLT = cms.string("HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_v"),
-        path1 = cms.vstring ("hltEle24WPLooseL1IsoEG22erTau20erGsfTrackIsoFilter", "hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau20"),
-        path2 = cms.vstring ("hltPFTau20TrackLooseIso", "hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau20"),
+        HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v"),
+        path1 = cms.vstring ("hltPreEle24eta2p1WPTightGsfLooseChargedIsoPFTau30eta2p1CrossL1","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
+        path2 = cms.vstring ("hltSelectedPFTau30LooseChargedIsolationL1HLTMatched","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
         leg1 = cms.int32(11),
         leg2 = cms.int32(15)
         ),
-    cms.PSet (
-        HLT = cms.string("HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1_v"),
-        path1 = cms.vstring ("hltEle24WPLooseL1SingleIsoEG22erGsfTrackIsoFilter", "hltOverlapFilterSingleIsoEle24WPLooseGsfLooseIsoPFTau20"),
-        path2 = cms.vstring ("hltPFTau20TrackLooseIso", "hltOverlapFilterSingleIsoEle24WPLooseGsfLooseIsoPFTau20"),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
-        ), ### ok
-    cms.PSet (
-        HLT = cms.string("HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau30_v"),
-        path1 = cms.vstring ("hltEle24WPLooseL1IsoEG22erIsoTau26erGsfTrackIsoFilter", "hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau30"),
-        path2 = cms.vstring ("hltPFTau30TrackLooseIso", "hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau30"),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
-        ), ### ok
 ### === tauh tauh triggers
     cms.PSet (
-        HLT = cms.string("HLT_DoubleMediumIsoPFTau32_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau32TrackPt1MediumIsolationDz02Reg"),
-        path2 = cms.vstring ("hltDoublePFTau32TrackPt1MediumIsolationDz02Reg"),
+        HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau35TrackPt1MediumChargedIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau35TrackPt1MediumChargedIsolationDz02Reg"),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau35TrackPt1MediumIsolationDz02Reg"),
-        path2 = cms.vstring ("hltDoublePFTau35TrackPt1MediumIsolationDz02Reg"),
+        HLT = cms.string("HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsDz02Reg"),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumIsolationDz02Reg"),
-        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumIsolationDz02Reg"),
+        HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg"),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_DoubleMediumCombinedIsoPFTau35_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau35TrackPt1MediumCombinedIsolationDz02Reg"),
-        path2 = cms.vstring ("hltDoublePFTau35TrackPt1MediumCombinedIsolationDz02Reg"),
+        HLT = cms.string("HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v8"),
+        path1 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
-    cms.PSet (
-        HLT = cms.string("HLT_DoubleMediumCombinedIsoPFTau40_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumCombinedIsolationDz02Reg"),
-        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumCombinedIsolationDz02Reg"),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_DoubleMediumCombinedIsoPFTau40_Trk1_eta2p1_v"),
-        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumCombinedIsolationDz02"),
-        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumCombinedIsolationDz02"),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
-        ),
-# ### === ele mu triggers
-     cms.PSet (
-         HLT = cms.string("HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v"),
-         path1 = cms.vstring ("hltMu17TrkIsoVVLEle12CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered17"),
-         path2 = cms.vstring ("hltMu17TrkIsoVVLEle12CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
-         leg1 = cms.int32(13),
-         leg2 = cms.int32(11)
-         ),
-     cms.PSet (
-         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v"),
-         path1 = cms.vstring ("hltMu8TrkIsoVVLEle17CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
-         path2 = cms.vstring ("hltMu8TrkIsoVVLEle17CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
-         leg1 = cms.int32(13),
-         leg2 = cms.int32(11)
-         ),
-    cms.PSet (
-         HLT = cms.string("HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v"),
-         path1 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered23"),
-         path2 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
-         leg1 = cms.int32(13),
-         leg2 = cms.int32(11)
-         ),
-    cms.PSet (
-         HLT = cms.string("HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_DZ_v"),
-         path1 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered23"),
-         path2 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
-         leg1 = cms.int32(13),
-         leg2 = cms.int32(11)
-         ),
-    cms.PSet (
-         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v"),
-         path1 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
-         path2 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
-         leg1 = cms.int32(13),
-         leg2 = cms.int32(11)
-         ),
-    cms.PSet (
-         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v"),
-         path1 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
-         path2 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
-         leg1 = cms.int32(13),
-         leg2 = cms.int32(11)
-         ),
-### === mu mu triggers 
+# ### === ele mu triggers -- TO BE DONE
+#     cms.PSet (
+#         HLT = cms.string("HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v"),
+#         path1 = cms.vstring ("hltMu17TrkIsoVVLEle12CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered17"),
+#         path2 = cms.vstring ("hltMu17TrkIsoVVLEle12CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+#         leg1 = cms.int32(13),
+#         leg2 = cms.int32(11)
+#         ),
+#     cms.PSet (
+#         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v"),
+#         path1 = cms.vstring ("hltMu8TrkIsoVVLEle17CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
+#         path2 = cms.vstring ("hltMu8TrkIsoVVLEle17CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+#         leg1 = cms.int32(13),
+#         leg2 = cms.int32(11)
+#         ),
+#    cms.PSet (
+#         HLT = cms.string("HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_v"),
+#         path1 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered23"),
+#         path2 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+#         leg1 = cms.int32(13),
+#         leg2 = cms.int32(11)
+#         ),
+#    cms.PSet (
+#         HLT = cms.string("HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_DZ_v"),
+#         path1 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered23"),
+#         path2 = cms.vstring ("hltMu23TrkIsoVVLEle8CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+#         leg1 = cms.int32(13),
+#         leg2 = cms.int32(11)
+#         ),
+#    cms.PSet (
+#         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v"),
+#         path1 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
+#         path2 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+#         leg1 = cms.int32(13),
+#         leg2 = cms.int32(11)
+#         ),
+#    cms.PSet (
+#         HLT = cms.string("HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v"),
+#         path1 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"),
+#         path2 = cms.vstring ("hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"),
+#         leg1 = cms.int32(13),
+#         leg2 = cms.int32(11)
+#         ),
+
+### === mu mu triggers  -- TO BE DONE
 ### FIXME!! MuMu and EleEle paths have not been checked in 80X and filter names are dummy
-    cms.PSet (
-        HLT = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(13)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(13)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_TripleMu_12_10_5_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(13)
-        ),
-### === ele ele triggers 
-    cms.PSet (
-        HLT = cms.string("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(11)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(11)
-        ),    
-    cms.PSet (
-        HLT = cms.string("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(13)
-        ),
-### === 3 lepton triggers 
-    cms.PSet (
-        HLT = cms.string("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(13),
-        leg2 = cms.int32(13)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(11),
-        leg2 = cms.int32(11)
-        ),
+#    cms.PSet (
+#        HLT = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v"),
+#        path1 = cms.vstring (""),
+#        path2 = cms.vstring (""),
+#        leg1 = cms.int32(13),
+#        leg2 = cms.int32(13)
+#        ),
+#    cms.PSet (
+#        HLT = cms.string("HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v"),
+#        path1 = cms.vstring (""),
+#        path2 = cms.vstring (""),
+#        leg1 = cms.int32(13),
+#        leg2 = cms.int32(13)
+#        ),
+#    cms.PSet (
+#        HLT = cms.string("HLT_TripleMu_12_10_5_v"),
+#        path1 = cms.vstring (""),
+#        path2 = cms.vstring (""),
+#        leg1 = cms.int32(13),
+#        leg2 = cms.int32(13)
+#        ),
+
+### === ele ele triggers  -- TO BE DONE
+#    cms.PSet (
+#        HLT = cms.string("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
+#        path1 = cms.vstring (""),
+#        path2 = cms.vstring (""),
+#        leg1 = cms.int32(11),
+#        leg2 = cms.int32(11)
+#        ),
+#    cms.PSet (
+#        HLT = cms.string("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
+#        path1 = cms.vstring (""),
+#        path2 = cms.vstring (""),
+#        leg1 = cms.int32(11),
+#        leg2 = cms.int32(11)
+#        ),
+#    cms.PSet (
+#        HLT = cms.string("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v"),
+#        path1 = cms.vstring (""),
+#        path2 = cms.vstring (""),
+#        leg1 = cms.int32(13),
+#        leg2 = cms.int32(13)
+#        ),
+        
+### === 3 lepton triggers  -- TO BE DONE
+#    cms.PSet (
+#        HLT = cms.string("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v"),
+#        path1 = cms.vstring (""),
+#        path2 = cms.vstring (""),
+#        leg1 = cms.int32(13),
+#        leg2 = cms.int32(13)
+#        ),
+#    cms.PSet (
+#        HLT = cms.string("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v"),
+#        path1 = cms.vstring (""),
+#        path2 = cms.vstring (""),
+#        leg1 = cms.int32(11),
+#        leg2 = cms.int32(11)
+#        ),
 ### === single tau triggers
     cms.PSet (
-        HLT = cms.string("HLT_VLooseIsoPFTau140_Trk50_eta2p1_v"),
-        path1 = cms.vstring ("hltPFTau140TrackPt50LooseAbsOrRelVLooseIso"),
+        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v"),
+        path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched"),
         path2 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
+        ),
+    #cms.PSet (
+    #    HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v"),
+    #    path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched1Prong"),
+    #    path2 = cms.vstring (""),
+    #    leg1 = cms.int32(15),
+    #    leg2 = cms.int32(999)
+    #    ),
+## === VBF + double-tau triggers
+    cms.PSet (
+        HLT = cms.string("HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
         ),
     )
 

--- a/NtupleProducer/src/LeptonIsoHelper.cc
+++ b/NtupleProducer/src/LeptonIsoHelper.cc
@@ -186,6 +186,13 @@ int LeptonIsoHelper::jetNDauChargedMVASel(const reco::Candidate* cand, pat::Jet 
   for (unsigned int i = 0, n = jet.numberOfSourceCandidatePtrs(); i < n; ++i) {
       
     const pat::PackedCandidate &dau_jet = dynamic_cast<const pat::PackedCandidate &>(*(jet.sourceCandidatePtr(i)));
+    
+    if (!dau_jet.bestTrack()) //FRA 
+    {
+      //std::cout << " ------ Skipping.." << std::endl;
+      continue;
+    }
+
     float dR = deltaR(jet,dau_jet);
     
     bool isgoodtrk = false;
@@ -199,7 +206,6 @@ int LeptonIsoHelper::jetNDauChargedMVASel(const reco::Candidate* cand, pat::Jet 
        std::fabs(trk.dxy(vtx_position))<0.2 &&
        std::fabs(trk.dz(vtx_position))<17
        ) isgoodtrk = true;
-    
     
     if( dR<=0.4 && dau_jet.charge()!=0 && dau_jet.fromPV()>1 && isgoodtrk)
       jetNDauCharged++;

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -29,7 +29,7 @@ APPLYTESCORRECTION=False # shift the central value of the tau energy scale befor
 COMPUTEUPDOWNSVFIT=True # compute SVfit for up/down TES variation
 doCPVariables=False # compute CP variables and PV refit
 COMPUTEQGVAR = False # compute QG Tagger for jets
-IsMC=True
+IsMC=False
 Is25ns=True
 HLTProcessName='HLT' #Different names possible, check e.g. at https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD.
 if not IsMC:
@@ -76,19 +76,31 @@ process.source = cms.Source("PoolSource",
     #'/store/mc/RunIISpring16MiniAODv2/SMS-TChiHH_HToBB_HToTauTau_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16Fast_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/00000/0264645E-5E12-E711-889B-E41D2D08DD10.root',
     # '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/60000/4CBBCFDF-F8C6-E611-A5C2-6CC2173BBD40.root',
     # '/store/mc/RunIISummer16MiniAODv2/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/00000/AC8AA010-88BB-E611-9974-FA163E1B885B.root',
-    '/store/mc/RunIISummer16MiniAODv2/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/80000/80EA9B8A-A1C1-E611-A107-20CF3027A61A.root',
-    # '/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/120000/E6D5D5EB-8299-E611-83D1-FA163EB4F61D.root',
-    #'/store/data/Run2016C/SingleMuon/MINIAOD/23Sep2016-v1/80000/F8F49A79-BE89-E611-A029-008CFA1974E4.root'
+    #'/store/mc/RunIISummer16MiniAODv2/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/80000/80EA9B8A-A1C1-E611-A107-20CF3027A61A.root',
+    #'/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/120000/E6D5D5EB-8299-E611-83D1-FA163EB4F61D.root',
+    ####'/store/data/Run2016C/SingleMuon/MINIAOD/23Sep2016-v1/80000/F8F49A79-BE89-E611-A029-008CFA1974E4.root'
     #'/store/data/Run2016B/SingleMuon/MINIAOD/PromptReco-v2/000/273/150/00000/34A57FB8-D819-E611-B0A4-02163E0144EE.root', #80X data
     # '/store/mc/RunIISpring16MiniAODv1/GluGluToBulkGravitonToHHTo2B2Tau_M-400_narrow_13TeV-madgraph/MINIAODSIM/PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_v3_ext1-v1/30000/06E22BEA-9F10-E611-9862-1CB72C0A3A5D.root', #80X MC
     # '/store/mc/RunIIFall15MiniAODv2/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/50000/12184969-3DB8-E511-879B-001E67504A65.root', #76X MC
+    
+    
+    # 2017 Data
+    # B_v1
+    #'/store/data/Run2017B/SingleMuon/MINIAOD/PromptReco-v1/000/297/046/00000/32AC3177-7A56-E711-BE34-02163E019D73.root',
+    '/store/data/Run2017B/SingleElectron/MINIAOD/PromptReco-v1/000/297/046/00000/02CBE6D1-4456-E711-82F5-02163E019D97.root',
+    #'/store/data/Run2017B/Tau/MINIAOD/PromptReco-v1/000/297/046/00000/B600F102-4856-E711-839A-02163E01411B.root',
+    # C_v3
+    #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/0AC61DCE-457E-E711-9CAE-02163E014217.root',
+    # root://cms-xrd-global.cern.ch//store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/240BA088-597E-E711-ADE4-02163E019C30.root
+    #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/240BA088-597E-E711-ADE4-02163E019C30.root',
+    #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/425DFEF6-5D7E-E711-8F2F-02163E01A1DD.root',
     )
 )
 
 # process.source.skipEvents = cms.untracked.uint32(968)
 
 #Limited nEv for testing purposes. -1 to run all events
-process.maxEvents.input = 1000
+process.maxEvents.input = 100
 
 # JSON mask for data --> defined in the lumiMask file
 # from JSON file
@@ -100,7 +112,7 @@ process.maxEvents.input = 1000
 ## Output file
 ##
 
-process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis.root'))
+process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis_TEST3.root'))
 
 if DO_ENRICHED:
     process.out = cms.OutputModule("PoolOutputModule",
@@ -137,7 +149,7 @@ process.p = cms.Path(process.Candidates)
 
 # Silence output
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
 #process.MessageLogger.categories.append('onlyError')
 #process.MessageLogger.cerr.onlyError=cms.untracked.PSet(threshold  = cms.untracked.string('ERROR'))
 #process.MessageLogger.cerr.threshold='ERROR'

--- a/NtupleProducer/test/datasets.txt
+++ b/NtupleProducer/test/datasets.txt
@@ -589,3 +589,25 @@
 /GluGluToRSGravitonToHHTo2B2Tau_M-300_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
 /GluGluToRSGravitonToHHTo2B2Tau_M-650_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
 /GluGluToRSGravitonToHHTo2B2Tau_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
+
+
+=== DATA2017 ===
+/SingleMuon/Run2017B-PromptReco-v1/MINIAOD
+/SingleMuon/Run2017B-PromptReco-v2/MINIAOD
+/SingleMuon/Run2017C-PromptReco-v1/MINIAOD
+/SingleMuon/Run2017C-PromptReco-v2/MINIAOD
+/SingleMuon/Run2017C-PromptReco-v3/MINIAOD
+/SingleMuon/Run2017D-PromptReco-v1/MINIAOD
+/SingleElectron/Run2017B-PromptReco-v1/MINIAOD
+/SingleElectron/Run2017B-PromptReco-v2/MINIAOD
+/SingleElectron/Run2017C-PromptReco-v1/MINIAOD
+/SingleElectron/Run2017C-PromptReco-v2/MINIAOD
+/SingleElectron/Run2017C-PromptReco-v3/MINIAOD
+/SingleElectron/Run2017D-PromptReco-v1/MINIAOD
+/Tau/Run2017B-PromptReco-v1/MINIAOD
+/Tau/Run2017B-PromptReco-v2/MINIAOD
+/Tau/Run2017C-PromptReco-v1/MINIAOD
+/Tau/Run2017C-PromptReco-v2/MINIAOD
+/Tau/Run2017C-PromptReco-v3/MINIAOD
+/Tau/Run2017D-PromptReco-v1/MINIAOD
+

--- a/NtupleProducer/test/submitAllDatasetOnCrab.py
+++ b/NtupleProducer/test/submitAllDatasetOnCrab.py
@@ -190,7 +190,8 @@ isMC = True
 # compareJSON.py --sub /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Cert_271036-275783_13TeV_PromptReco_Collisions16_JSON.txt /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Cert_271036-275125_13TeV_PromptReco_Collisions16_JSON.txt 8lugJSON_diff_22giuJSON.txt
 # lumiMaskFileName = "15lug_NoL1TJSON_diff_8lugJSON.txt"
 # lumiMaskFileName = "20lug_NoL1TJSON_diff_15lug_NoL1TJSON.txt"
-lumiMaskFileName = 'Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt'
+#lumiMaskFileName = 'Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt'
+lumiMaskFileName = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/PromptReco/Cert_294927-302663_13TeV_PromptReco_Collisions17_JSON.txt'
 
 FastJobs = False # controls number of jobs - true if skipping SVfit, false if computing it (jobs will be smaller)
 VeryLong = True # controls time for each job - set to true if jobs contain many real lepton pairs --> request for more grid time


### PR DESCRIPTION
Many changes to be able to run on 2017 data (miniAOD):
- triggers_92X.py contains the new trigger paths/filters for 2017 data
- dataset.txt is updated with PromptReco 2017 data
- submitAllDatasetOnCrab.py updated with new lumi mask
- LeptonIsoHelper.cc : check on PackedCandidated before asking for a track
- HiggsTauTauProducer_92X.py : 
    - added "slimmedSecondaryVertices" collection (secondary vtx information for jets); 
    - replaced trigger collection with "slimmedPatTrigger"; 
    - new GlobalTag
- HTauTauNtuplizer.cc:
    - modified HTauTauNtuplizer::FillJet to read the secondary vertex information for jets 
      (variables are not stored anymore as UserFloats in the jet collection)
    - unpacking Filter Labels in trigger
 