### PR TITLE
2017 recipes in 92X+ 

### DIFF
--- a/NtupleProducer/interface/triggerMapper.h
+++ b/NtupleProducer/interface/triggerMapper.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <sstream>
 #include <utility>
+#include <iostream> //FRA
 
 using namespace std;
 
@@ -29,13 +30,17 @@ class triggerMapper {
   triggerMapper(const triggerMapper& trigMap);
   triggerMapper(string, std::vector<std::string>,std::vector<std::string>, int);
   triggerMapper(string, std::vector<std::string>,std::vector<std::string>, int theleg1ID, int theleg2ID);
+  triggerMapper(string, std::vector<std::string>,std::vector<std::string>, std::vector<std::string>, std::vector<std::string>, int theleg1ID, int theleg2ID); //FRA
   //triggerMapper(TString, TString*,TString*,int,int);
   triggerMapper(string, string, string, int);
   
   string GetHLTPath(){return HLT;}
   int GetNfiltersleg1(){return filter_leg1.size();}
   int GetNfiltersleg2(){return filter_leg2.size();}
+  int GetNfiltersleg3(){return filter_leg3.size();} //FRA
+  int GetNfiltersleg4(){return filter_leg4.size();} //FRA
   string Getfilter(bool isleg1, int iFilter);
+  string GetfilterVBF(bool isleg3, int iFilter); //FRA
   std::vector<std::string> Getfilters(bool isleg1){return (isleg1 ? filter_leg1 : filter_leg2); };
   int GetTriggerChannel(){return channel;}
   pair <int, int> GetTriggerLegsID(){return make_pair(leg1ID, leg2ID);}
@@ -47,6 +52,8 @@ class triggerMapper {
   string HLT;
   std::vector<string> filter_leg1;
   std::vector<string> filter_leg2;
+  std::vector<string> filter_leg3; //FRA
+  std::vector<string> filter_leg4; //FRA
   int channel; // final decay channel: mu tau, ele tau, ...
   int leg1ID; //  abs(pdgID) of leg 1
   int leg2ID; //  abs(pdgID) of leg 2

--- a/NtupleProducer/interface/triggerhelper.h
+++ b/NtupleProducer/interface/triggerhelper.h
@@ -31,6 +31,7 @@ class triggerhelper {
 
   void addTriggerMap(string hlt,vector<string> path1, vector<string> path2, int channel);
   void addTriggerMap(string hlt,vector<string> path1, vector<string> path2, int leg1ID, int leg2ID);
+  void addTriggerMap(string hlt,vector<string> path1, vector<string> path2, vector<string> path3, vector<string> path4, int leg1ID, int leg2ID); //FRA
   Long64_t FindTriggerBit(const edm::Event&, const vector<string>, const vector<int>, const edm::Handle<edm::TriggerResults>& triggerResults);
   int FindMETBit(const edm::Event&, edm::EDGetTokenT<edm::TriggerResults> metFilterBitsToken);
   

--- a/NtupleProducer/plugins/EleFiller.cc
+++ b/NtupleProducer/plugins/EleFiller.cc
@@ -226,7 +226,8 @@ EleFiller::EleFiller(const edm::ParameterSet& iConfig) :
     bool isconversionveto=l.passConversionVeto();
     
     //-- Missing hit  
-    int missinghit = l.gsfTrack()->hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS);
+    //int missinghit = l.gsfTrack()->hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS);
+    int missinghit = l.gsfTrack()->hitPattern().numberOfAllHits(HitPattern::MISSING_INNER_HITS);
 
     //--- 3 charge assignement
     bool isGsfCtfScPixChargeConsistent=l.isGsfCtfScPixChargeConsistent();

--- a/NtupleProducer/plugins/EleFiller.cc
+++ b/NtupleProducer/plugins/EleFiller.cc
@@ -226,7 +226,7 @@ EleFiller::EleFiller(const edm::ParameterSet& iConfig) :
     bool isconversionveto=l.passConversionVeto();
     
     //-- Missing hit  
-    int missinghit = l.gsfTrack()->hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS);
+    int missinghit = l.gsfTrack()->hitPattern().numberOfAllHits(HitPattern::MISSING_INNER_HITS);
 
     //--- 3 charge assignement
     bool isGsfCtfScPixChargeConsistent=l.isGsfCtfScPixChargeConsistent();

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -1917,14 +1917,14 @@ void HTauTauNtuplizer::VBFtrigMatch (const edm::View<pat::Jet> *jets, const edm:
         std::vector<std::string> pathNamesAll  = obj.pathNames(false);
         std::vector<std::string> pathNamesLast = obj.pathNames(true);
         
-       // debug: checking TO filter labels //FRA
-       //if ( obj.type(85))
-       //{
-         //const std::vector<std::string>& VLabels = obj.filterLabels(); //FRA
-         ////printing TO labels //FRA
-         //std::cout << " -- VLabels for TO "<< idxto << " - pt: " << obj.pt() << " - phi: " << obj.phi() << std::endl; //FRA
-         //for (uint ll = 0; ll < VLabels.size(); ++ll) cout << "    -- " << VLabels.at(ll) << endl; //FRA
-       //}
+        // debug: checking TO filter labels //FRA
+        //if ( obj.type(85))
+        //{
+          //const std::vector<std::string>& VLabels = obj.filterLabels(); //FRA
+          //printing TO labels //FRA
+          //std::cout << " -- VLabels for TO "<< idxto << " - pt: " << obj.pt() << " - phi: " << obj.phi() << std::endl; //FRA
+          //for (uint ll = 0; ll < VLabels.size(); ++ll) cout << "    -- " << VLabels.at(ll) << endl; //FRA
+        //}
         
         // Loop on the HLT path names in the Trigger Object
         for (unsigned h = 0, n = pathNamesAll.size(); h < n; ++h)
@@ -2818,14 +2818,14 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
           // FIXME: should I check type? --> no, multiple filters should be enough
           if(istrgMatched)
           {
-            std::cout << " ###### GOOD MATCH ######" << std::endl; //FRA
-            std::cout << "***** searching trigger : " << myTriggerHelper -> printTriggerName(triggerbit) << " " << trgmap.GetHLTPath() << std::endl; //FRA
+            //std::cout << " ###### GOOD MATCH ######" << std::endl; //FRA
+            //std::cout << "***** searching trigger : " << myTriggerHelper -> printTriggerName(triggerbit) << " " << trgmap.GetHLTPath() << std::endl; //FRA
             //std::cout << "--> triggerbit: " << triggerbit << std::endl; //FRA
             //std::cout << "--> label: " << label << std::endl; //FRA
             //std::cout << "--> BEFORE trgMatched: " << std::bitset<64>(trgMatched) << std::endl; //FRA
             
             //printing TO labels //FRA
-            for (uint ll = 0; ll < vLabels.size(); ++ll) cout << "    -- " << vLabels.at(ll) << endl; //FRA
+            //for (uint ll = 0; ll < vLabels.size(); ++ll) cout << "    -- " << vLabels.at(ll) << endl; //FRA
             
             trgMatched |= (long(1) <<triggerbit);
             toStandaloneMatched.at(triggerbit).push_back(idxto);

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -569,6 +569,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _jets_mT;
   std::vector<Float_t> _jets_PUJetID;
   std::vector<Float_t> _jets_PUJetIDupdated;
+  std::vector<Int_t>   _jets_PUJetIDupdated_WP;
   std::vector<Float_t> _jets_vtxPt;
   std::vector<Float_t> _jets_vtxMass;
   std::vector<Float_t> _jets_vtx3dL;
@@ -1014,6 +1015,7 @@ void HTauTauNtuplizer::Initialize(){
   _jets_mT.clear();
   _jets_PUJetID.clear();
   _jets_PUJetIDupdated.clear();
+  _jets_PUJetIDupdated_WP.clear();
   _jets_vtxPt.clear();
   _jets_vtxMass.clear();
   _jets_vtx3dL.clear();
@@ -1358,6 +1360,7 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("jets_genjetIndex", &_jets_genjetIndex);
   myTree->Branch("jets_PUJetID",&_jets_PUJetID);
   myTree->Branch("jets_PUJetIDupdated",&_jets_PUJetIDupdated);
+  myTree->Branch("jets_PUJetIDupdated_WP",&_jets_PUJetIDupdated_WP);
   myTree->Branch("jets_vtxPt", &_jets_vtxPt);
   myTree->Branch("jets_vtxMass", &_jets_vtxMass);
   myTree->Branch("jets_vtx3dL", &_jets_vtx3dL);
@@ -2051,6 +2054,8 @@ int HTauTauNtuplizer::FillJet(const edm::View<pat::Jet> *jets, const edm::Event&
     _jets_HadronFlavour.push_back(ijet->hadronFlavour());
     _jets_PUJetID.push_back(ijet->userFloat("pileupJetId:fullDiscriminant"));
     _jets_PUJetIDupdated.push_back(ijet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant") ? ijet->userFloat("pileupJetIdUpdated:fullDiscriminant") : -999);
+    _jets_PUJetIDupdated_WP.push_back(ijet->hasUserInt("pileupJetIdUpdated:fullId") ? ijet->userInt("pileupJetIdUpdated:fullId") : -999);
+
     
     //float vtxPx = ijet->userFloat ("vtxPx");                      //FRA: not anymore available in 2017
     //float vtxPy = ijet->userFloat ("vtxPy");                      //FRA: not anymore available in 2017

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -484,7 +484,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
    "byLooseIsolationMVArun2v1DBdR03oldDMwLT",
    "byMediumIsolationMVArun2v1DBdR03oldDMwLT",
    "byTightIsolationMVArun2v1DBdR03oldDMwLT",
-   "byVTightIsolationMVArun2v1DBdR03oldDMwLT"
+   "byVTightIsolationMVArun2v1DBdR03oldDMwLT",
   };
   std::vector<Float_t> _daughters_IetaIeta;
   std::vector<Float_t> _daughters_full5x5_IetaIeta;
@@ -513,6 +513,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _daughters_byIsolationMVA3newDMwoLTraw;
   std::vector<Float_t> _daughters_byIsolationMVA3newDMwLTraw;
   std::vector<Float_t> _daughters_byIsolationMVArun2v1DBoldDMwLTraw;
+  std::vector<Float_t> _daughters_byIsolationMVArun2v1DBoldDMwLTrawNew; //FRA
   std::vector<Float_t> _daughters_chargedIsoPtSum;
   std::vector<Float_t> _daughters_neutralIsoPtSum;
   std::vector<Float_t> _daughters_puCorrPtSum;
@@ -797,6 +798,7 @@ void HTauTauNtuplizer::Initialize(){
   _daughters_byIsolationMVA3oldDMwLTraw.clear();
   _daughters_byIsolationMVA3newDMwoLTraw.clear();
   _daughters_byIsolationMVArun2v1DBoldDMwLTraw.clear();
+  _daughters_byIsolationMVArun2v1DBoldDMwLTrawNew.clear(); //FRA
 
   _daughters_againstElectronMVA5category.clear();
   _daughters_againstElectronMVA5raw.clear();
@@ -1302,6 +1304,7 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("daughters_byIsolationMVA3newDMwoLTraw",&_daughters_byIsolationMVA3newDMwoLTraw);
   myTree->Branch("daughters_byIsolationMVA3newDMwLTraw",&_daughters_byIsolationMVA3newDMwLTraw);
   myTree->Branch("daughters_byIsolationMVArun2v1DBoldDMwLTraw",&_daughters_byIsolationMVArun2v1DBoldDMwLTraw);
+  myTree->Branch("daughters_byIsolationMVArun2v1DBoldDMwLTrawNew",&_daughters_byIsolationMVArun2v1DBoldDMwLTrawNew); //FRA
   myTree->Branch("daughters_chargedIsoPtSum", &_daughters_chargedIsoPtSum);
   myTree->Branch("daughters_neutralIsoPtSum", &_daughters_neutralIsoPtSum);
   myTree->Branch("daughters_puCorrPtSum", &_daughters_puCorrPtSum);
@@ -2148,27 +2151,46 @@ int HTauTauNtuplizer::FillJet(const edm::View<pat::Jet> *jets, const edm::Event&
     // }  
     
     // https://twiki.cern.ch/twiki/bin/view/CMS/JetID#Recommendations_for_13_TeV_data
-    bool looseJetID = false;
+    // bool looseJetID = false;
+    // bool tightJetID = false;
+    // bool tightLepVetoJetID = false;
+    // if (absjeta <= 2.7)
+    // {
+    //   looseJetID = ( (NHF<0.99 && NEMF<0.99 && NumConst>1) && ((absjeta<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || absjeta>2.4) );
+    //   tightJetID = ( (NHF<0.90 && NEMF<0.90 && NumConst>1) && ((absjeta<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || absjeta>2.4) );
+    //   tightLepVetoJetID = ( (NHF<0.90 && NEMF<0.90 && NumConst>1 && MUF<0.8) && ((absjeta<=2.4 && CHF>0 && CHM>0 && CEMF<0.90) || absjeta>2.4) );
+    // }
+    // else if (absjeta <= 3.0)
+    // {
+    //   looseJetID = (NEMF<0.90 && NumNeutralParticles>2 ) ;
+    //   tightJetID = looseJetID;
+    // }
+    // else
+    // {
+    //   looseJetID = (NEMF<0.90 && NumNeutralParticles>10 );
+    //   tightJetID = looseJetID;
+    // }
+    // if (looseJetID) ++jetid;
+    // if (tightJetID) ++jetid;
+    // if (tightLepVetoJetID) ++jetid;
+
+    // https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13TeVRun2017
+    // Since the tight JetID efficiency is > 99% everywhere, loose is not recommended anymore
     bool tightJetID = false;
     bool tightLepVetoJetID = false;
-
     if (absjeta <= 2.7)
     {
-      looseJetID = ( (NHF<0.99 && NEMF<0.99 && NumConst>1) && ((absjeta<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || absjeta>2.4) );
-      tightJetID = ( (NHF<0.90 && NEMF<0.90 && NumConst>1) && ((absjeta<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || absjeta>2.4) );
-      tightLepVetoJetID = ( (NHF<0.90 && NEMF<0.90 && NumConst>1 && MUF<0.8) && ((absjeta<=2.4 && CHF>0 && CHM>0 && CEMF<0.90) || absjeta>2.4) );
+      tightJetID = ( (NHF<0.90 && NEMF<0.90 && NumConst>1) && ((absjeta<=2.4 && CHF>0 && CHM>0) || absjeta>2.4) );
+      tightLepVetoJetID = ( (NHF<0.90 && NEMF<0.90 && NumConst>1 && MUF<0.8) && ((absjeta<=2.4 && CHF>0 && CHM>0 && CEMF<0.80) || absjeta>2.4) );
     }
     else if (absjeta <= 3.0)
     {
-      looseJetID = (NEMF<0.90 && NumNeutralParticles>2 ) ;
-      tightJetID = looseJetID;
+      tightJetID = (NEMF>0.02 && NEMF<0.99 && NumNeutralParticles>2 );
     }
     else
     {
-      looseJetID = (NEMF<0.90 && NumNeutralParticles>10 );
-      tightJetID = looseJetID;   
+      tightJetID = (NEMF<0.90 && NHF>0.02 && NumNeutralParticles>10 );
     }
-    if (looseJetID) ++jetid;
     if (tightJetID) ++jetid;
     if (tightLepVetoJetID) ++jetid;
 
@@ -2474,7 +2496,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     int numChargedParticlesSignalCone=-1, numNeutralHadronsSignalCone=-1, numPhotonsSignalCone=-1, numParticlesSignalCone=-1, numChargedParticlesIsoCone=-1, numNeutralHadronsIsoCone=-1, numPhotonsIsoCone=-1, numParticlesIsoCone=-1;
     float leadChargedParticlePt=-1., trackRefPt=-1.;
     int typeOfMuon=0;
-    float byIsolationMVA3oldDMwoLTraw=-1, byIsolationMVA3oldDMwLTraw=-1,  byIsolationMVA3newDMwoLTraw=-1,byIsolationMVA3newDMwLTraw=-1, byIsolationMVArun2v1DBoldDMwLTraw=-1;
+    float byIsolationMVA3oldDMwoLTraw=-1, byIsolationMVA3oldDMwLTraw=-1,  byIsolationMVA3newDMwoLTraw=-1,byIsolationMVA3newDMwLTraw=-1, byIsolationMVArun2v1DBoldDMwLTraw=-1, byIsolationMVArun2v1DBoldDMwLTrawNew=-1; //, byLooseIsolationMVArun2v1DBoldDMwLTNew=-1; //FRA
     Long64_t tauIDflag = 0;
     float   
     againstElectronMVA5category,
@@ -2585,6 +2607,8 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
       byIsolationMVA3newDMwoLTraw=userdatahelpers::getUserFloat (cand, "byIsolationMVA3newDMwoLTraw");
       byIsolationMVA3newDMwLTraw=userdatahelpers::getUserFloat (cand, "byIsolationMVA3newDMwLTraw");
       byIsolationMVArun2v1DBoldDMwLTraw=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2v1DBoldDMwLTraw");
+      byIsolationMVArun2v1DBoldDMwLTrawNew=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2v1DBoldDMwLTrawNew"); //FRA
+      //byLooseIsolationMVArun2v1DBoldDMwLTNew=userdatahelpers::getUserFloat (cand, "byLooseIsolationMVArun2v1DBoldDMwLTNew"); //FRA
       chargedIsoPtSum = userdatahelpers::getUserFloat (cand, "chargedIsoPtSum");
       neutralIsoPtSum = userdatahelpers::getUserFloat (cand, "neutralIsoPtSum");
       puCorrPtSum = userdatahelpers::getUserFloat (cand, "puCorrPtSum");
@@ -2658,6 +2682,8 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     _daughters_byIsolationMVA3newDMwoLTraw.push_back(byIsolationMVA3newDMwoLTraw);
     _daughters_byIsolationMVA3newDMwLTraw.push_back(byIsolationMVA3newDMwLTraw);
     _daughters_byIsolationMVArun2v1DBoldDMwLTraw.push_back(byIsolationMVArun2v1DBoldDMwLTraw);
+    _daughters_byIsolationMVArun2v1DBoldDMwLTrawNew.push_back(byIsolationMVArun2v1DBoldDMwLTrawNew); //FRA
+    //_daughters_byLooseIsolationMVArun2v1DBoldDMwLTNew.push_back(byLooseIsolationMVArun2v1DBoldDMwLTNew); //FRA
     _daughters_numChargedParticlesSignalCone.push_back(numChargedParticlesSignalCone);
     _daughters_numNeutralHadronsSignalCone.push_back(numNeutralHadronsSignalCone);
     _daughters_numPhotonsSignalCone.push_back(numPhotonsSignalCone);
@@ -3245,8 +3271,10 @@ bool HTauTauNtuplizer::ComparePairsbyIso(pat::CompositeCandidate i, pat::Composi
   //byCombinedIsolationDeltaBetaCorrRaw3Hits
   isoi=userdatahelpers::getUserFloat(i.daughter(cand1i),"combRelIsoPF");
   isoj=userdatahelpers::getUserFloat(j.daughter(cand1j),"combRelIsoPF");
-  if (!i.daughter(cand1i)->isMuon() && !i.daughter(cand1i)->isElectron()) isoi= -userdatahelpers::getUserFloat(i.daughter(cand1i),"byIsolationMVArun2v1DBoldDMwLTraw");
-  if (!j.daughter(cand1j)->isMuon() && !j.daughter(cand1j)->isElectron()) isoj= -userdatahelpers::getUserFloat(j.daughter(cand1j),"byIsolationMVArun2v1DBoldDMwLTraw");
+  //if (!i.daughter(cand1i)->isMuon() && !i.daughter(cand1i)->isElectron()) isoi= -userdatahelpers::getUserFloat(i.daughter(cand1i),"byIsolationMVArun2v1DBoldDMwLTraw"); //FRA
+  //if (!j.daughter(cand1j)->isMuon() && !j.daughter(cand1j)->isElectron()) isoj= -userdatahelpers::getUserFloat(j.daughter(cand1j),"byIsolationMVArun2v1DBoldDMwLTraw"); //FRA
+  if (!i.daughter(cand1i)->isMuon() && !i.daughter(cand1i)->isElectron()) isoi= -userdatahelpers::getUserFloat(i.daughter(cand1i),"byIsolationMVArun2v1DBoldDMwLTrawNew"); //FRA
+  if (!j.daughter(cand1j)->isMuon() && !j.daughter(cand1j)->isElectron()) isoj= -userdatahelpers::getUserFloat(j.daughter(cand1j),"byIsolationMVArun2v1DBoldDMwLTrawNew"); //FRA
 
   if (isoi<isoj)return true;
   else if(isoi>isoj)return false;
@@ -3258,8 +3286,10 @@ bool HTauTauNtuplizer::ComparePairsbyIso(pat::CompositeCandidate i, pat::Composi
   //step 3, leg 2 ISO
   isoi=userdatahelpers::getUserFloat(i.daughter(1-cand1i),"combRelIsoPF");
   isoj=userdatahelpers::getUserFloat(j.daughter(1-cand1j),"combRelIsoPF");
-  if (!i.daughter(1-cand1i)->isMuon() && !i.daughter(1-cand1i)->isElectron()) isoi= -userdatahelpers::getUserFloat(i.daughter(1-cand1i),"byIsolationMVArun2v1DBoldDMwLTraw");
-  if (!j.daughter(1-cand1j)->isMuon() && !j.daughter(1-cand1j)->isElectron()) isoj= -userdatahelpers::getUserFloat(j.daughter(1-cand1j),"byIsolationMVArun2v1DBoldDMwLTraw");
+  //if (!i.daughter(1-cand1i)->isMuon() && !i.daughter(1-cand1i)->isElectron()) isoi= -userdatahelpers::getUserFloat(i.daughter(1-cand1i),"byIsolationMVArun2v1DBoldDMwLTraw"); //FRA
+  //if (!j.daughter(1-cand1j)->isMuon() && !j.daughter(1-cand1j)->isElectron()) isoj= -userdatahelpers::getUserFloat(j.daughter(1-cand1j),"byIsolationMVArun2v1DBoldDMwLTraw"); //FRA
+  if (!i.daughter(1-cand1i)->isMuon() && !i.daughter(1-cand1i)->isElectron()) isoi= -userdatahelpers::getUserFloat(i.daughter(1-cand1i),"byIsolationMVArun2v1DBoldDMwLTrawNew"); //FRA
+  if (!j.daughter(1-cand1j)->isMuon() && !j.daughter(1-cand1j)->isElectron()) isoj= -userdatahelpers::getUserFloat(j.daughter(1-cand1j),"byIsolationMVArun2v1DBoldDMwLTrawNew"); //FRA
 
   if (isoi<isoj)return true;
   else if(isoi>isoj)return false;

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -1891,6 +1891,8 @@ void HTauTauNtuplizer::VBFtrigMatch (const edm::View<pat::Jet> *jets, const edm:
   {
     //numero = numero+1; //FRA
     //std::cout << "Jet " << numero << std::endl; //FRA
+    //std::cout << " -- pt:  " << ijet->pt() << std::endl; //FRA
+    //std::cout << " -- phi: " << ijet->phi() << std::endl; //FRA
     
     // For each jet, check all the trigger objects, both 'path3' and 'path4'
     Long64_t firstJetMatched  = 0;
@@ -1900,6 +1902,9 @@ void HTauTauNtuplizer::VBFtrigMatch (const edm::View<pat::Jet> *jets, const edm:
     for (size_t idxto = 0; idxto < triggerObjects->size(); ++idxto)
     {
       pat::TriggerObjectStandAlone obj = triggerObjects->at(idxto);
+      
+      // Check if the TO type is a jet, otherwise continue with next TO
+      if (obj.type(85) != true ) continue;
     
       // DeltaR2 match between jet and trigger object
       if(deltaR2(obj,*ijet)<0.25)
@@ -1912,11 +1917,14 @@ void HTauTauNtuplizer::VBFtrigMatch (const edm::View<pat::Jet> *jets, const edm:
         std::vector<std::string> pathNamesAll  = obj.pathNames(false);
         std::vector<std::string> pathNamesLast = obj.pathNames(true);
         
-        // TO filter labels //FRA
-        //const std::vector<std::string>& VLabels = obj.filterLabels(); //FRA
-        //printing TO labels //FRA
-        //std::cout << "  VLabels for TO "<< idxto << ": " << std::endl; //FRA
-        //for (uint ll = 0; ll < VLabels.size(); ++ll) cout << "    -- " << VLabels.at(ll) << endl; //FRA
+       // debug: checking TO filter labels //FRA
+       //if ( obj.type(85))
+       //{
+         //const std::vector<std::string>& VLabels = obj.filterLabels(); //FRA
+         ////printing TO labels //FRA
+         //std::cout << " -- VLabels for TO "<< idxto << " - pt: " << obj.pt() << " - phi: " << obj.phi() << std::endl; //FRA
+         //for (uint ll = 0; ll < VLabels.size(); ++ll) cout << "    -- " << VLabels.at(ll) << endl; //FRA
+       //}
         
         // Loop on the HLT path names in the Trigger Object
         for (unsigned h = 0, n = pathNamesAll.size(); h < n; ++h)

--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -132,8 +132,7 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "againstElectronLooseMVA6",
     "againstElectronMediumMVA6",
     "againstElectronTightMVA6",
-    "againstElectronVTightMVA6"
-
+    "againstElectronVTightMVA6",
   };
 
   tauFloatDiscrims_ =
@@ -153,6 +152,7 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "chargedIsoPtSum",
     "neutralIsoPtSum",
     "puCorrPtSum",
+    "byIsolationMVArun2v1DBoldDMwLTrawNew", //FRA
   };
 
 

--- a/NtupleProducer/python/HiggsTauTauProducer_92X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_92X.py
@@ -429,8 +429,131 @@ process.cleanSoftElectrons = cms.EDProducer("PATElectronCleaner",
 ##
 ## Taus
 ##
+
+from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
+process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
+from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
+
+tauIdDiscrMVA_trainings_run2_2017 = {
+  'tauIdMVAIsoDBoldDMwLT2017' : "tauIdMVAIsoDBoldDMwLT2017",
+  }
+tauIdDiscrMVA_WPs_run2_2017 = {
+  'tauIdMVAIsoDBoldDMwLT2017' : {
+    'Eff95' : "DBoldDMwLTEff95",
+    'Eff90' : "DBoldDMwLTEff90",
+    'Eff80' : "DBoldDMwLTEff80",
+    'Eff70' : "DBoldDMwLTEff70",
+    'Eff60' : "DBoldDMwLTEff60",
+    'Eff50' : "DBoldDMwLTEff50",
+    'Eff40' : "DBoldDMwLTEff40"
+    }
+  }
+tauIdDiscrMVA_2017_version = "v1"
+
+def loadMVA_WPs_run2_2017(process):
+                
+      for training, gbrForestName in tauIdDiscrMVA_trainings_run2_2017.items():
+
+         process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
+            cms.PSet(
+               record = cms.string('GBRWrapperRcd'),
+               tag = cms.string("RecoTauTag_%s%s" % (gbrForestName, tauIdDiscrMVA_2017_version)),
+               label = cms.untracked.string("RecoTauTag_%s%s" % (gbrForestName, tauIdDiscrMVA_2017_version))
+            )
+         )
+
+         for WP in tauIdDiscrMVA_WPs_run2_2017[training].keys():
+            process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
+               cms.PSet(
+                  record = cms.string('PhysicsTGraphPayloadRcd'),
+                  tag = cms.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, tauIdDiscrMVA_2017_version, WP)),
+                  label = cms.untracked.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, tauIdDiscrMVA_2017_version, WP))
+               )
+            )
+
+         process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
+            cms.PSet(
+               record = cms.string('PhysicsTFormulaPayloadRcd'),
+               tag = cms.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, tauIdDiscrMVA_2017_version)),
+               label = cms.untracked.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, tauIdDiscrMVA_2017_version))
+            )
+)
+
+loadMVA_WPs_run2_2017(process)
+
+process.rerunDiscriminationByIsolationMVArun2v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
+   PATTauProducer = cms.InputTag('slimmedTaus'),
+   Prediscriminants = noPrediscriminants,
+   loadMVAfromDB = cms.bool(True),
+   mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1"),  # name of the training you want to use: training with 2017 MC_v1 for oldDM
+   mvaOpt = cms.string("DBoldDMwLTwGJ"), # option you want to use for your training (i.e., which variables are used to compute the BDT score)
+   requireDecayMode = cms.bool(True),
+   verbosity = cms.int32(0)
+)
+
+process.rerunDiscriminationByIsolationMVArun2v1VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
+   PATTauProducer = cms.InputTag('slimmedTaus'),    
+   Prediscriminants = noPrediscriminants,
+   toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1raw'),
+   key = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1raw:category'),
+   loadMVAfromDB = cms.bool(True),
+   mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_mvaOutput_normalization"), # normalization fo the training you want to use
+   mapping = cms.VPSet(
+      cms.PSet(
+         category = cms.uint32(0),
+         cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff90"), # this is the name of the working point you want to use
+         variable = cms.string("pt"),
+      )
+   )
+)
+
+# here we produce all the other working points for the training
+process.rerunDiscriminationByIsolationMVArun2v1VVLoose = process.rerunDiscriminationByIsolationMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationMVArun2v1VVLoose.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff95")
+process.rerunDiscriminationByIsolationMVArun2v1Loose = process.rerunDiscriminationByIsolationMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationMVArun2v1Loose.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff80")
+process.rerunDiscriminationByIsolationMVArun2v1Medium = process.rerunDiscriminationByIsolationMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationMVArun2v1Medium.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff70")
+process.rerunDiscriminationByIsolationMVArun2v1Tight = process.rerunDiscriminationByIsolationMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationMVArun2v1Tight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff60")
+process.rerunDiscriminationByIsolationMVArun2v1VTight = process.rerunDiscriminationByIsolationMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationMVArun2v1VTight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff50")
+process.rerunDiscriminationByIsolationMVArun2v1VVTight = process.rerunDiscriminationByIsolationMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationMVArun2v1VVTight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff40")
+
+# this sequence has to be included in your cms.Path() before your analyzer which accesses the new variables is called.
+process.rerunMvaIsolation2SeqRun2 = cms.Sequence(
+   process.rerunDiscriminationByIsolationMVArun2v1raw
+   *process.rerunDiscriminationByIsolationMVArun2v1VLoose
+   *process.rerunDiscriminationByIsolationMVArun2v1VVLoose
+   *process.rerunDiscriminationByIsolationMVArun2v1Loose
+   *process.rerunDiscriminationByIsolationMVArun2v1Medium
+   *process.rerunDiscriminationByIsolationMVArun2v1Tight
+   *process.rerunDiscriminationByIsolationMVArun2v1VTight
+   *process.rerunDiscriminationByIsolationMVArun2v1VVTight
+)
+
+# embed new id's into new tau collection
+embedID = cms.EDProducer("PATTauIDEmbedder",
+   src = cms.InputTag('slimmedTaus'),
+   tauIDSources = cms.PSet(
+      byIsolationMVArun2v1DBoldDMwLTrawNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1raw'),
+      byVLooseIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1VLoose'),
+      byVVLooseIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1VVLoose'),
+      byLooseIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1Loose'),
+      byMediumIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1Medium'),
+      byTightIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1Tight'),
+      byVTightIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1VTight'),
+      byVVTightIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1VVTight'),
+      ),
+   )
+
+setattr(process, "NewTauIDsEmbedded", embedID)
+
+# old sequence starts here
 process.bareTaus = cms.EDFilter("PATTauRefSelector",
-   src = cms.InputTag("slimmedTaus"),
+   #src = cms.InputTag("slimmedTaus"),
+   src = cms.InputTag("NewTauIDsEmbedded"),
    cut = cms.string(TAUCUT),
    )
 
@@ -527,7 +650,7 @@ process.softTaus = cms.EDProducer("TauFiller",
 #     )
 
 
-process.taus=cms.Sequence(process.bareTaus + process.softTaus)
+process.taus=cms.Sequence(process.rerunMvaIsolation2SeqRun2 + process.NewTauIDsEmbedded + process.bareTaus + process.softTaus)
 
 # process.tausMerged = cms.EDProducer("MergeTauCollections",
 #     src        = cms.InputTag("softTaus"),

--- a/NtupleProducer/python/HiggsTauTauProducer_92X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_92X.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-#execfile(PyFilePath+"python/triggers_92X.py") # contains the list of triggers and filters
-execfile(PyFilePath+"python/triggers_92X_test.py") # contains the list of triggers and filters
+execfile(PyFilePath+"python/triggers_92X.py") # contains the list of triggers and filters
+#execfile(PyFilePath+"python/triggers_92X_test.py") # contains the list of triggers and filters
 
 process = cms.Process("TEST")
 
@@ -52,7 +52,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 if IsMC:
     #process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_TrancheIV_v6' # FIXME !!!!!!!!
     #process.GlobalTag.globaltag = '92X_dataRun2_2017Repro_v4'               # 12Sept2017 MC
-    process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'            # 2017 MC test
+    process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'            # 2017 MC 
 else :
     # process.GlobalTag.globaltag = '80X_dataRun2_Prompt_ICHEP16JEC_v0' # ICHEP            # FIXME !!!!!!!!
     #process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v7' # Run B-G               # FIXME !!!!!!!!

--- a/NtupleProducer/python/HiggsTauTauProducer_92X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_92X.py
@@ -52,12 +52,12 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 if IsMC:
     #process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_TrancheIV_v6' # FIXME !!!!!!!!
     #process.GlobalTag.globaltag = '92X_dataRun2_2017Repro_v4'               # 12Sept2017 MC
-    process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'            # 2017 MC 
+    process.GlobalTag.globaltag = '94X_mc2017_realistic_v10'                 # 2017 MC
 else :
     # process.GlobalTag.globaltag = '80X_dataRun2_Prompt_ICHEP16JEC_v0' # ICHEP            # FIXME !!!!!!!!
     #process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v7' # Run B-G               # FIXME !!!!!!!!
     # process.GlobalTag.globaltag = '80X_dataRun2_Prompt_v16' # Run H                      # FIXME !!!!!!!!
-    process.GlobalTag.globaltag = '92X_dataRun2_Prompt_v4'                                 # 2017 Data
+    process.GlobalTag.globaltag = '94X_dataRun2_ReReco17_forValidation'                    # 2017 Data
 print process.GlobalTag.globaltag
 
 nanosec="25"

--- a/NtupleProducer/python/HiggsTauTauProducer_92X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_92X.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-execfile(PyFilePath+"python/triggers_92X.py") # contains the list of triggers and filters
+#execfile(PyFilePath+"python/triggers_92X.py") # contains the list of triggers and filters
+execfile(PyFilePath+"python/triggers_92X_test.py") # contains the list of triggers and filters
 
 process = cms.Process("TEST")
 
@@ -49,8 +50,9 @@ from Configuration.AlCa.autoCond import autoCond
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")    
 #process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 if IsMC:
-    process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_TrancheIV_v6' # FIXME !!!!!!!!
+    #process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_TrancheIV_v6' # FIXME !!!!!!!!
     #process.GlobalTag.globaltag = '92X_dataRun2_2017Repro_v4'               # 12Sept2017 MC
+    process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'            # 2017 MC test
 else :
     # process.GlobalTag.globaltag = '80X_dataRun2_Prompt_ICHEP16JEC_v0' # ICHEP            # FIXME !!!!!!!!
     #process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v7' # Run B-G               # FIXME !!!!!!!!

--- a/NtupleProducer/python/HiggsTauTauProducer_92X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_92X.py
@@ -592,13 +592,13 @@ process.softLeptons = cms.EDProducer("CandViewMerger",
 #
 
 # # add latest pileup jet ID
-# process.load("RecoJets.JetProducers.PileupJetID_cfi")
-# process.pileupJetIdUpdated = process.pileupJetId.clone(
-#   jets = cms.InputTag("slimmedJets"),
-#   inputIsCorrected = True,
-#   applyJec = True,
-#   vertexes = cms.InputTag("offlineSlimmedPrimaryVertices")
-# )
+process.load("RecoJets.JetProducers.PileupJetID_cfi")
+process.pileupJetIdUpdated = process.pileupJetId.clone(
+   jets = cms.InputTag("slimmedJets"),
+   inputIsCorrected = True,
+   applyJec = True,
+   vertexes = cms.InputTag("offlineSlimmedPrimaryVertices")
+)
 #print process.pileupJetIdUpdated.dumpConfig()
 
 # apply new jet energy corrections
@@ -617,7 +617,10 @@ updateJetCollection(
    jetCorrections = ('AK4PFchs', cms.vstring(jecLevels), 'None')
 )
 
-process.jecSequence = cms.Sequence(process.patJetCorrFactorsUpdatedJEC * process.updatedPatJetsUpdatedJEC)
+process.updatedPatJetsUpdatedJEC.userData.userFloats.src += ['pileupJetIdUpdated:fullDiscriminant']
+process.updatedPatJetsUpdatedJEC.userData.userInts.src    += ['pileupJetIdUpdated:fullId']
+process.jecSequence = cms.Sequence(process.pileupJetIdUpdated + process.patJetCorrFactorsUpdatedJEC * process.updatedPatJetsUpdatedJEC)
+#process.jecSequence = cms.Sequence(process.patJetCorrFactorsUpdatedJEC * process.updatedPatJetsUpdatedJEC)
 
 process.jets = cms.EDFilter("PATJetRefSelector",
                             #src = cms.InputTag("slimmedJets"),

--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -17,6 +17,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_IsoMu27_v"),
         path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"),
         path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(13),
         leg2 = cms.int32(999)
         ),
@@ -24,6 +26,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_IsoMu24_v"), # ---------- it's prescaled: TO BE REMOVED
         path1 = cms.vstring ("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07"),
         path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(13),
         leg2 = cms.int32(999)
         ),
@@ -32,6 +36,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_Ele32_WPTight_Gsf_v"),
         path1 = cms.vstring ("hltEle32WPTightGsfTrackIsoFilter"),
         path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(999)
         ),
@@ -39,6 +45,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_Ele35_WPTight_Gsf_v"),
         path1 = cms.vstring ("hltEle35noerWPTightGsfTrackIsoFilter"),
         path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(999)
         ),
@@ -47,6 +55,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1_v"),
         path1 = cms.vstring ("hltSelectedPFTau27LooseChargedIsolationAgainstMuonL1HLTMatched","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
         path2 = cms.vstring ("hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(13),
         leg2 = cms.int32(15)
         ),
@@ -54,6 +64,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_SingleL1_v"),
         path1 = cms.vstring ("hltL3crIsoL1sSingleMu22erL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24LooseChargedIsoPFTau20"),
         path2 = cms.vstring ("hltPFTau20TrackLooseChargedIsoAgainstMuon","hltOverlapFilterIsoMu24LooseChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(13),
         leg2 = cms.int32(15)
         ),
@@ -62,6 +74,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v"),
         path1 = cms.vstring ("hltEle24erWPTightGsfTrackIsoFilterForTau","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
         path2 = cms.vstring ("hltSelectedPFTau30LooseChargedIsolationL1HLTMatched","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(15)
         ),
@@ -70,6 +84,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v"), # ---------- it's prescaled: TO BE REMOVED
         path1 = cms.vstring ("hltDoublePFTau35TrackPt1MediumChargedIsolationDz02Reg"),
         path2 = cms.vstring ("hltDoublePFTau35TrackPt1MediumChargedIsolationDz02Reg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
@@ -77,6 +93,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v"),
         path1 = cms.vstring ("hltDoublePFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsDz02Reg"),
         path2 = cms.vstring ("hltDoublePFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsDz02Reg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
@@ -84,6 +102,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v"),
         path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg"),
         path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
@@ -91,6 +111,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v"),
         path1 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
         path2 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
@@ -205,6 +227,8 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v"),     # Do we need this?? probably not...
         path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched"),
         path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
         ),
@@ -212,31 +236,58 @@ HLTLIST = cms.VPSet(
         HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v"), # Do we need this?? probably not...
         path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched1Prong"),
         path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
         ),
 ## === VBF + double-tau triggers
     cms.PSet (
         HLT = cms.string("HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),
-        path2 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),
+        path1 = cms.vstring ("hltDoublePFTau20TrackPt1LooseChargedIsolationReg"),                    # hadronic tau
+        path2 = cms.vstring ("hltDoublePFTau20TrackPt1LooseChargedIsolationReg"),                    # hadronic tau
+        path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTau20"), # 2 jets with pt>40
+        path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),  # 1 jet with pt>115
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v"), #FIXME
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
+        HLT = cms.string("HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau20TrackPt1MediumChargedIsolationReg"),                    # hadronic tau
+        path2 = cms.vstring ("hltDoublePFTau20TrackPt1MediumChargedIsolationReg"),                    # hadronic tau
+        path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumChargedIsoPFTau20"), # 2 jets with pt>40
+        path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumChargedIsoPFTau20"),  # 1 jet with pt>115
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v"), #FIXME
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
+        HLT = cms.string("HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
+        path2 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
+        path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleTightChargedIsoPFTau20"), # 2 jets with pt>40
+        path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleTightChargedIsoPFTau20"),  # 1 jet with pt>115
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
+## === 4 jets (for VBF) # FILTERS TO BE FIXED
+    #cms.PSet (
+    #    HLT = cms.string("HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v7"), #FIXME
+    #    path1 = cms.vstring (""), # tau filters
+    #    path2 = cms.vstring (""), # tau filters
+    #    path3 = cms.vstring ("hltVBFPFJetCSVSortedMqq460Detaqq3p5"), # 4 jets
+    #    path4 = cms.vstring (""),
+    #    leg1 = cms.int32(999),
+    #    leg2 = cms.int32(999)
+    #    ),
+    #cms.PSet (
+    #    HLT = cms.string("HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v7"),  #FIXME
+    #    path1 = cms.vstring (""), # tau filters
+    #    path2 = cms.vstring (""), # tau filters
+    #    path3 = cms.vstring ("hltVBFPFJetCSVSortedMqq200Detaqq1p5"), # 6 jets
+    #    path4 = cms.vstring (""),  # 1 jet with pt>115
+    #    leg1 = cms.int32(999),
+    #    leg2 = cms.int32(999)
+    #    ),
     )
 
 #now I create the trigger list for HLTconfig

--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -99,18 +99,18 @@ HLTLIST = cms.VPSet(
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg"),
-        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg"),
+        HLT = cms.string("HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
-        path2 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
+        HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg"),
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
@@ -266,6 +266,16 @@ HLTLIST = cms.VPSet(
         path2 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
         path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleTightChargedIsoPFTau20"), # 2 jets with pt>40
         path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleTightChargedIsoPFTau20"),  # 1 jet with pt>115
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+## === Tau + MET
+    cms.PSet (
+        HLT = cms.string("HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET90_v"),
+        path1 = cms.vstring ("hltPFTau50TrackPt30MediumAbsOrRelIso1Prong", "hltSelectedPFTau50MediumChargedIsolationL1HLTMatched"),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),

--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -12,7 +12,7 @@ TRIGGERLIST=[]
 # channel: kemu=0, ketau=1,kmutau=2,ktautau=3
 HLTLIST = cms.VPSet(
 
-### === Single muon triggers
+### === Single muon triggers - OK
     cms.PSet (
         HLT = cms.string("HLT_IsoMu27_v"),
         path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"),
@@ -21,13 +21,13 @@ HLTLIST = cms.VPSet(
         leg2 = cms.int32(999)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_IsoMu24_v"),
+        HLT = cms.string("HLT_IsoMu24_v"), # ---------- it's prescaled: TO BE REMOVED
         path1 = cms.vstring ("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07"),
         path2 = cms.vstring (""),
         leg1 = cms.int32(13),
         leg2 = cms.int32(999)
         ),
-### === Single electron triggers
+### === Single electron triggers - OK
     cms.PSet (
         HLT = cms.string("HLT_Ele32_WPTight_Gsf_v"),
         path1 = cms.vstring ("hltEle32WPTightGsfTrackIsoFilter"),
@@ -42,32 +42,32 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(11),
         leg2 = cms.int32(999)
         ),
-### === mu tauh triggers
+### === mu tauh triggers - OK
     cms.PSet (
         HLT = cms.string("HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1_v"),
-        path1 = cms.vstring ("hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
-        path2 = cms.vstring ("hltSelectedPFTau27LooseChargedIsolationAgainstMuonL1HLTMatched","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
+        path1 = cms.vstring ("hltSelectedPFTau27LooseChargedIsolationAgainstMuonL1HLTMatched","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
+        path2 = cms.vstring ("hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
         leg1 = cms.int32(13),
         leg2 = cms.int32(15)
         ),
-    cms.PSet (
+    cms.PSet ( # this is right, it's wrong on the twiki  # ---------- it's prescaled: TO BE REMOVED
         HLT = cms.string("HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_SingleL1_v"),
         path1 = cms.vstring ("hltL3crIsoL1sSingleMu22erL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24LooseChargedIsoPFTau20"),
         path2 = cms.vstring ("hltPFTau20TrackLooseChargedIsoAgainstMuon","hltOverlapFilterIsoMu24LooseChargedIsoPFTau20"),
         leg1 = cms.int32(13),
         leg2 = cms.int32(15)
         ),
-### === ele tauh triggers
+### === ele tauh triggers - OK
     cms.PSet (
         HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v"),
-        path1 = cms.vstring ("hltPreEle24eta2p1WPTightGsfLooseChargedIsoPFTau30eta2p1CrossL1","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
+        path1 = cms.vstring ("hltEle24erWPTightGsfTrackIsoFilterForTau","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
         path2 = cms.vstring ("hltSelectedPFTau30LooseChargedIsolationL1HLTMatched","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
         leg1 = cms.int32(11),
         leg2 = cms.int32(15)
         ),
-### === tauh tauh triggers
+### === tauh tauh triggers - OK
     cms.PSet (
-        HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v"),
+        HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v"), # ---------- it's prescaled: TO BE REMOVED
         path1 = cms.vstring ("hltDoublePFTau35TrackPt1MediumChargedIsolationDz02Reg"),
         path2 = cms.vstring ("hltDoublePFTau35TrackPt1MediumChargedIsolationDz02Reg"),
         leg1 = cms.int32(15),
@@ -88,7 +88,7 @@ HLTLIST = cms.VPSet(
         leg2 = cms.int32(15)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v8"),
+        HLT = cms.string("HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v"),
         path1 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
         path2 = cms.vstring ("hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg"),
         leg1 = cms.int32(15),
@@ -200,26 +200,40 @@ HLTLIST = cms.VPSet(
 #        leg1 = cms.int32(11),
 #        leg2 = cms.int32(11)
 #        ),
-### === single tau triggers
+### === single tau triggers - OK
     cms.PSet (
-        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v"),
+        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v"),     # Do we need this?? probably not...
         path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched"),
         path2 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
         ),
-    #cms.PSet (
-    #    HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v"),
-    #    path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched1Prong"),
-    #    path2 = cms.vstring (""),
-    #    leg1 = cms.int32(15),
-    #    leg2 = cms.int32(999)
-    #    ),
+    cms.PSet (
+        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v"), # Do we need this?? probably not...
+        path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched1Prong"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+        ),
 ## === VBF + double-tau triggers
     cms.PSet (
         HLT = cms.string("HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
         path1 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),
         path2 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v"), #FIXME
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v"), #FIXME
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),

--- a/NtupleProducer/python/triggers_92X_test.py
+++ b/NtupleProducer/python/triggers_92X_test.py
@@ -1,0 +1,129 @@
+import FWCore.ParameterSet.Config as cms
+
+## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v 
+## do not remove any other part of path name or the check will give meaningless results!
+
+## leg numbering: write the object type the two legs refer to
+## 11: electrons, 13: muons, 15: taus, 999: others/unused (e.g. leg 2 in single muon)
+##
+
+TRIGGERLIST=[]
+#list triggers and filter paths here!
+# channel: kemu=0, ketau=1,kmutau=2,ktautau=3
+HLTLIST = cms.VPSet(
+
+### === Single muon triggers
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(999)
+        ),
+### === Single electron triggers
+    cms.PSet (
+        HLT = cms.string("HLT_Ele35_WPTight_Gsf_v"),
+        path1 = cms.vstring ("hltEle35noerWPTightGsfTrackIsoFilter"),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(999)
+        ),
+### === single tau triggers
+    cms.PSet (
+        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v"),
+        path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched"),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+        ),
+### === mu tauh triggers
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1_v"),
+        path1 = cms.vstring ("hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
+        path2 = cms.vstring ("hltSelectedPFTau27LooseChargedIsolationAgainstMuonL1HLTMatched","hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+### === ele tauh triggers
+    cms.PSet (
+        HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v"),
+        path1 = cms.vstring ("hltEle24erWPTightGsfTrackIsoFilterForTau","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
+        path2 = cms.vstring ("hltSelectedPFTau30LooseChargedIsolationL1HLTMatched","hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(15)
+        ),
+### === tauh tauh triggers
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau35TrackPt1MediumChargedIsolationDz02Reg"),
+        path2 = cms.vstring ("hltDoublePFTau35TrackPt1MediumChargedIsolationDz02Reg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+## === VBF + double-tau triggers
+    cms.PSet (
+        HLT = cms.string("HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau20TrackPt1LooseChargedIsolationReg"),                    # hadronic tau
+        path2 = cms.vstring ("hltDoublePFTau20TrackPt1LooseChargedIsolationReg"),                    # hadronic tau
+        path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTau20"), # 2 jets with pt>40
+        path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),  # 1 jet with pt>115
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau20TrackPt1MediumChargedIsolationReg"),                    # hadronic tau
+        path2 = cms.vstring ("hltDoublePFTau20TrackPt1MediumChargedIsolationReg"),                    # hadronic tau
+        path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumChargedIsoPFTau20"), # 2 jets with pt>40
+        path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumChargedIsoPFTau20"),  # 1 jet with pt>115
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
+        path1 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
+        path2 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
+        path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleTightChargedIsoPFTau20"), # 2 jets with pt>40
+        path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleTightChargedIsoPFTau20"),  # 1 jet with pt>115
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(15)
+        ),
+## === 4 jets (for VBF)
+    cms.PSet (
+        HLT = cms.string("HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v7"), #FIXME
+        path1 = cms.vstring (""), # tau filters
+        path2 = cms.vstring (""), # tau filters
+        path3 = cms.vstring ("hltVBFPFJetCSVSortedMqq460Detaqq3p5"), # 4 jets
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v7"),  #FIXME
+        path1 = cms.vstring (""), # tau filters
+        path2 = cms.vstring (""), # tau filters
+        path3 = cms.vstring ("hltVBFPFJetCSVSortedMqq200Detaqq1p5"), # 6 jets
+        path4 = cms.vstring (""),  # 1 jet with pt>115
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+    )
+
+#now I create the trigger list for HLTconfig
+for i in range(len(HLTLIST)):
+    tmpl =  str(HLTLIST[i].HLT).replace('cms.string(\'','') ##CMSSW Vaffanculo
+    tmpl = tmpl.replace('\')','') ##CMSSW Vaffanculo x 2
+    TRIGGERLIST.append(tmpl)
+#print TRIGGERLIST

--- a/NtupleProducer/python/triggers_92X_test.py
+++ b/NtupleProducer/python/triggers_92X_test.py
@@ -82,24 +82,24 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
-    cms.PSet (
-        HLT = cms.string("HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau20TrackPt1MediumChargedIsolationReg"),                    # hadronic tau
-        path2 = cms.vstring ("hltDoublePFTau20TrackPt1MediumChargedIsolationReg"),                    # hadronic tau
-        path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumChargedIsoPFTau20"), # 2 jets with pt>40
-        path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumChargedIsoPFTau20"),  # 1 jet with pt>115
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
-        path1 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
-        path2 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
-        path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleTightChargedIsoPFTau20"), # 2 jets with pt>40
-        path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleTightChargedIsoPFTau20"),  # 1 jet with pt>115
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
-        ),
+    #cms.PSet (
+    #    HLT = cms.string("HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
+    #    path1 = cms.vstring ("hltDoublePFTau20TrackPt1MediumChargedIsolationReg"),                    # hadronic tau
+    #    path2 = cms.vstring ("hltDoublePFTau20TrackPt1MediumChargedIsolationReg"),                    # hadronic tau
+    #    path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumChargedIsoPFTau20"), # 2 jets with pt>40
+    #    path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumChargedIsoPFTau20"),  # 1 jet with pt>115
+    #    leg1 = cms.int32(15),
+    #    leg2 = cms.int32(15)
+    #    ),
+    #cms.PSet (
+    #    HLT = cms.string("HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
+    #    path1 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
+    #    path2 = cms.vstring ("hltDoublePFTau20TrackPt1TightChargedIsolationReg"),                    # hadronic tau
+    #    path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleTightChargedIsoPFTau20"), # 2 jets with pt>40
+    #    path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleTightChargedIsoPFTau20"),  # 1 jet with pt>115
+    #    leg1 = cms.int32(15),
+    #    leg2 = cms.int32(15)
+    #    ),
 ## === 4 jets (for VBF)
     cms.PSet (
         HLT = cms.string("HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v7"), #FIXME

--- a/NtupleProducer/src/triggerMapper.cc
+++ b/NtupleProducer/src/triggerMapper.cc
@@ -34,6 +34,8 @@ triggerMapper::triggerMapper(const triggerMapper& trigMap)
   HLT = trigMap.HLT;
   filter_leg1 = trigMap.filter_leg1;
   filter_leg2 = trigMap.filter_leg2;
+  filter_leg3 = trigMap.filter_leg3; //FRA
+  filter_leg4 = trigMap.filter_leg4; //FRA
   channel = trigMap.channel;
   leg1ID = trigMap.leg1ID;
   leg2ID = trigMap.leg2ID;
@@ -41,6 +43,7 @@ triggerMapper::triggerMapper(const triggerMapper& trigMap)
 
 
 triggerMapper::triggerMapper(string HLTtrigger, std::vector<string> filters1, std::vector<string> filters2, int c){
+
   HLT=HLTtrigger;
   int n1 = filters1.size();
   int n2 = filters2.size();
@@ -106,6 +109,32 @@ triggerMapper::triggerMapper(string HLTtrigger, std::vector<std::string> filters
 
 }
 
+//FRA : adding filters3 and 4 for VBF matching
+triggerMapper::triggerMapper(string HLTtrigger, std::vector<std::string> filters1, std::vector<std::string> filters2, std::vector<std::string> filters3, std::vector<std::string> filters4, int theleg1ID, int theleg2ID)
+{
+  HLT=HLTtrigger;
+  int n1 = filters1.size();
+  int n2 = filters2.size();
+  int n3 = filters3.size();
+  int n4 = filters4.size();
+    
+  for(int i=0;i<n1;i++){filter_leg1.push_back(filters1.at(i));}
+  for(int i=0;i<n2;i++){filter_leg2.push_back(filters2.at(i));}
+  for(int i=0;i<n3;i++){filter_leg3.push_back(filters3.at(i));}
+  for(int i=0;i<n4;i++){filter_leg4.push_back(filters4.at(i));}
+
+  leg1ID = theleg1ID;
+  leg2ID = theleg2ID;
+
+  if      (leg1ID == (int) kele && leg2ID == (int) kmu)  channel = (int) kemu;
+  else if (leg1ID == (int) kele && leg2ID == (int) ktau) channel = (int) ketau;
+  else if (leg1ID == (int) kmu  && leg2ID == (int) ktau) channel = (int) kmutau;
+  else if (leg1ID == (int) ktau && leg2ID == (int) ktau) channel = (int) ktautau;
+  else if (leg1ID == (int) kmu  && leg2ID == (int) kmu)  channel = (int) kmumu;
+  else if (leg1ID == (int) kele && leg2ID == (int) kele) channel = (int) kee;
+  else channel = 999;
+
+}
 
 triggerMapper::triggerMapper(string HLTtrigger, string filter1, string filter2, int c){
   HLT=HLTtrigger;
@@ -153,7 +182,10 @@ triggerMapper::~triggerMapper(){
   //HLT="";//delete HLT;
   filter_leg1.clear();
   filter_leg2.clear();
+  filter_leg3.clear(); //FRA
+  filter_leg4.clear(); //FRA
 }
+
 
 string triggerMapper::Getfilter(bool isleg1,int iFilter){
   string result("");
@@ -163,6 +195,18 @@ string triggerMapper::Getfilter(bool isleg1,int iFilter){
   }else {
     if(iFilter>(int)(filter_leg2.size()))cout<<"TRIGGER MAPPER ERROR NFILTER "<<iFilter<<endl;
     else result=filter_leg2.at(iFilter);
+  }
+  return result;
+}
+
+string triggerMapper::GetfilterVBF(bool isleg3,int iFilter){
+  string result("");
+  if(isleg3){
+    if(iFilter>(int)(filter_leg3.size()))cout<<"TRIGGER MAPPER ERROR NFILTER "<<iFilter<<endl;
+    else result=filter_leg3.at(iFilter);
+  }else {
+    if(iFilter>(int)(filter_leg4.size()))cout<<"TRIGGER MAPPER ERROR NFILTER "<<iFilter<<endl;
+    else result=filter_leg4.at(iFilter);
   }
   return result;
 }

--- a/NtupleProducer/src/triggerhelper.cc
+++ b/NtupleProducer/src/triggerhelper.cc
@@ -107,6 +107,22 @@ void triggerhelper::addTriggerMap(string hlt,vector<string> path1, vector<string
   triggerMap.push_back(map);
 }
 
+//FRA : added path3 and path4 for VBF matching with jets
+void triggerhelper::addTriggerMap(string hlt,vector<string> path1, vector<string> path2, vector<string> path3, vector<string> path4, int leg1ID, int leg2ID)
+{
+
+  if (find(triggerlist.begin(), triggerlist.end(), hlt) != triggerlist.end() )
+  {
+    cout << "** triggerHelper :: Warning: path " << hlt << " already added, skipping" << endl;
+    return;
+  }
+
+  triggerlist.push_back(hlt);
+  triggerMapper map(hlt, path1, path2, path3, path4, leg1ID, leg2ID);
+  triggerMap.push_back(map);
+}
+
+
 Long64_t triggerhelper::FindTriggerBit(const edm::Event& event, const vector<string> foundPaths, const vector<int> indexOfPaths, const edm::Handle<edm::TriggerResults>& triggerResults){
   
   Long64_t bit =0;
@@ -168,9 +184,13 @@ int triggerhelper::FindMETBit(const edm::Event& event, edm::EDGetTokenT<edm::Tri
 }
 
 triggerMapper triggerhelper::GetTriggerMap(string path){
+
   for(int i=0;i<(int)triggerMap.size();i++){
     //if(triggerMap.at(i).GetHLTPath().compare(path)==0)return triggerMap.at(i); // full name comparison
-    if (path.find(triggerMap.at(i).GetHLTPath()) != std::string::npos) return triggerMap.at(i); // use av equivalent of "contains" for versioning wildcard
+    if (path.find(triggerMap.at(i).GetHLTPath()) != std::string::npos)
+    {
+      return triggerMap.at(i); // use av equivalent of "contains" for versioning wildcard
+    }
   }
   cout << "** trigger mapper : error : path " << path << " not found in triggerMap stored , return empty map" << endl;
   return triggerMapper();

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -23,7 +23,7 @@ USEPAIRMET=False # input to SVfit: true: MVA pair MET; false: PFmet (HF inclusio
 APPLYMETCORR=False # flag to enable (True) and disable (False) Z-recoil corrections for MVA MET response and resolution
 USE_NOHFMET = False # True to exclude HF and run on silver json
 
-SVFITBYPASS=False # use SVFitBypass module, no SVfit computation, adds dummy userfloats for MET and SVfit mass
+SVFITBYPASS=True # use SVFitBypass module, no SVfit computation, adds dummy userfloats for MET and SVfit mass
 USECLASSICSVFIT=True # if True use the ClassicSVfit package, if False use the SVFitStandAlone package
 
 BUILDONLYOS=False #If true don't create the collection of SS candidates (and thus don't run SV fit on them)
@@ -31,7 +31,7 @@ APPLYTESCORRECTION=False # shift the central value of the tau energy scale befor
 COMPUTEUPDOWNSVFIT=True # compute SVfit for up/down TES variation
 doCPVariables=False # compute CP variables and PV refit
 COMPUTEQGVAR = False # compute QG Tagger for jets
-IsMC=False
+IsMC=True
 Is25ns=True
 HLTProcessName='HLT' #Different names possible, check e.g. at https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD.
 if not IsMC:
@@ -89,20 +89,32 @@ process.source = cms.Source("PoolSource",
     # 2017 Data
     # B_v1
     #'/store/data/Run2017B/SingleMuon/MINIAOD/PromptReco-v1/000/297/046/00000/32AC3177-7A56-E711-BE34-02163E019D73.root',
-    '/store/data/Run2017B/SingleElectron/MINIAOD/PromptReco-v1/000/297/046/00000/02CBE6D1-4456-E711-82F5-02163E019D97.root',
+    #'/store/data/Run2017B/SingleElectron/MINIAOD/PromptReco-v1/000/297/046/00000/02CBE6D1-4456-E711-82F5-02163E019D97.root', # 5000   evts
+    #'/store/data/Run2017B/SingleElectron/MINIAOD/PromptReco-v1/000/297/050/00000/166F7BB0-3C56-E711-BD8B-02163E0145C5.root',  # 147000 evts
     #'/store/data/Run2017B/Tau/MINIAOD/PromptReco-v1/000/297/046/00000/B600F102-4856-E711-839A-02163E01411B.root',
     # C_v3
     #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/0AC61DCE-457E-E711-9CAE-02163E014217.root',
     # root://cms-xrd-global.cern.ch//store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/240BA088-597E-E711-ADE4-02163E019C30.root
     #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/240BA088-597E-E711-ADE4-02163E019C30.root',
     #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/425DFEF6-5D7E-E711-8F2F-02163E01A1DD.root',
+    
+    # MC 2017 - GT:92X_upgrade2017_realistic_v10
+    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/0080A67C-FBA4-E711-A8FE-00259029E84C.root',
+    '/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/0678C84B-F49E-E711-B561-A0369FC51AD4.root',
+    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/088CC59F-F39C-E711-8124-549F35AF44E3.root',
+    
+    # 2017 embedded samples - GT: 92X_dataRun2_Prompt_v4
+    #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_0.root',    # 688 evts
+    #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_100.root',  # 715 evts
+    #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_1000.root', # 657 evts
+    
     )
 )
 
 # process.source.skipEvents = cms.untracked.uint32(968)
 
 #Limited nEv for testing purposes. -1 to run all events
-process.maxEvents.input = 1000
+process.maxEvents.input = 100
 
 # JSON mask for data --> defined in the lumiMask file
 # from JSON file
@@ -114,7 +126,13 @@ process.maxEvents.input = 1000
 ## Output file
 ##
 
-process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis.root'))
+process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis_VBFmatch.root'))
+
+# L1 trigger objects (as suggested on: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorking2017#Trigger_Information )
+#  ----> TO BE FIXED <----
+#process.out.outputCommands.append('keep *_caloStage2Digis_*_*') #FRA
+#process.out.outputCommands.append('keep *_gmtStage2Digis_*_*')  #FRA
+
 
 if DO_ENRICHED:
     process.out = cms.OutputModule("PoolOutputModule",
@@ -151,7 +169,7 @@ process.p = cms.Path(process.Candidates)
 
 # Silence output
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 10
 #process.MessageLogger.categories.append('onlyError')
 #process.MessageLogger.cerr.onlyError=cms.untracked.PSet(threshold  = cms.untracked.string('ERROR'))
 #process.MessageLogger.cerr.threshold='ERROR'

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -136,7 +136,7 @@ process.maxEvents.input = -1 # FRA
 ## Output file
 ##
 
-process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis_VBFmatch.root'))
+process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis_grav.root'))
 
 # L1 trigger objects (as suggested on: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorking2017#Trigger_Information )
 #  ----> TO BE FIXED <----

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -28,7 +28,7 @@ USECLASSICSVFIT=True # if True use the ClassicSVfit package, if False use the SV
 
 BUILDONLYOS=False #If true don't create the collection of SS candidates (and thus don't run SV fit on them)
 APPLYTESCORRECTION=False # shift the central value of the tau energy scale before computing up/down variations
-COMPUTEUPDOWNSVFIT=True # compute SVfit for up/down TES variation
+COMPUTEUPDOWNSVFIT=False # compute SVfit for up/down TES variation
 doCPVariables=False # compute CP variables and PV refit
 COMPUTEQGVAR = False # compute QG Tagger for jets
 IsMC=True
@@ -100,7 +100,7 @@ process.source = cms.Source("PoolSource",
     
     # MC 2017 - GT:92X_upgrade2017_realistic_v10
     #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/0080A67C-FBA4-E711-A8FE-00259029E84C.root',
-    '/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/0678C84B-F49E-E711-B561-A0369FC51AD4.root',
+    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/0678C84B-F49E-E711-B561-A0369FC51AD4.root',
     #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/088CC59F-F39C-E711-8124-549F35AF44E3.root',
     
     # 2017 embedded samples - GT: 92X_dataRun2_Prompt_v4
@@ -108,13 +108,17 @@ process.source = cms.Source("PoolSource",
     #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_100.root',  # 715 evts
     #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_1000.root', # 657 evts
     
+    
+    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10-v2/50000/02098EBB-029C-E711-8FED-441EA1714E4C.root'
+    '/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10-v2/50000/2A50557C-829D-E711-9331-10983627C3CE.root',
     )
 )
 
 # process.source.skipEvents = cms.untracked.uint32(968)
+#process.source.eventsToProcess = cms.untracked.VEventRange("1:2347130-1:2347130") # run only on event=2347130 (syntax= from run:evt - to run:evt)
 
 #Limited nEv for testing purposes. -1 to run all events
-process.maxEvents.input = 100
+process.maxEvents.input = 10 # FRA
 
 # JSON mask for data --> defined in the lumiMask file
 # from JSON file
@@ -169,7 +173,7 @@ process.p = cms.Path(process.Candidates)
 
 # Silence output
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 10
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
 #process.MessageLogger.categories.append('onlyError')
 #process.MessageLogger.cerr.onlyError=cms.untracked.PSet(threshold  = cms.untracked.string('ERROR'))
 #process.MessageLogger.cerr.threshold='ERROR'

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -118,7 +118,7 @@ process.source = cms.Source("PoolSource",
 #process.source.eventsToProcess = cms.untracked.VEventRange("1:2347130-1:2347130") # run only on event=2347130 (syntax= from run:evt - to run:evt)
 
 #Limited nEv for testing purposes. -1 to run all events
-process.maxEvents.input = 10 # FRA
+process.maxEvents.input = 50 # FRA
 
 # JSON mask for data --> defined in the lumiMask file
 # from JSON file

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -124,7 +124,7 @@ process.source = cms.Source("PoolSource",
 #process.source.eventsToProcess = cms.untracked.VEventRange("1:2347130-1:2347130") # run only on event=2347130 (syntax= from run:evt - to run:evt)
 
 #Limited nEv for testing purposes. -1 to run all events
-process.maxEvents.input = -1 # FRA
+process.maxEvents.input = -1
 
 # JSON mask for data --> defined in the lumiMask file
 # from JSON file
@@ -136,7 +136,7 @@ process.maxEvents.input = -1 # FRA
 ## Output file
 ##
 
-process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis_TEST.root'))
+process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis.root'))
 
 # L1 trigger objects (as suggested on: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorking2017#Trigger_Information )
 #  ----> TO BE FIXED <----

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -23,11 +23,11 @@ USEPAIRMET=False # input to SVfit: true: MVA pair MET; false: PFmet (HF inclusio
 APPLYMETCORR=False # flag to enable (True) and disable (False) Z-recoil corrections for MVA MET response and resolution
 USE_NOHFMET = False # True to exclude HF and run on silver json
 
-SVFITBYPASS=True # use SVFitBypass module, no SVfit computation, adds dummy userfloats for MET and SVfit mass
+SVFITBYPASS=False # use SVFitBypass module, no SVfit computation, adds dummy userfloats for MET and SVfit mass
 USECLASSICSVFIT=True # if True use the ClassicSVfit package, if False use the SVFitStandAlone package
 
-BUILDONLYOS=False #If true don't create the collection of SS candidates (and thus don't run SV fit on them)
-APPLYTESCORRECTION=False # shift the central value of the tau energy scale before computing up/down variations
+BUILDONLYOS=True #If true don't create the collection of SS candidates (and thus don't run SV fit on them)
+APPLYTESCORRECTION=True # shift the central value of the tau energy scale before computing up/down variations
 COMPUTEUPDOWNSVFIT=False # compute SVfit for up/down TES variation
 doCPVariables=False # compute CP variables and PV refit
 COMPUTEQGVAR = False # compute QG Tagger for jets
@@ -108,9 +108,15 @@ process.source = cms.Source("PoolSource",
     #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_100.root',  # 715 evts
     #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_1000.root', # 657 evts
     
-    
     #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10-v2/50000/02098EBB-029C-E711-8FED-441EA1714E4C.root'
-    '/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10-v2/50000/2A50557C-829D-E711-9331-10983627C3CE.root',
+    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10-v2/50000/2A50557C-829D-E711-9331-10983627C3CE.root',
+    
+    # Samples for SyncFeb2018
+    # Signal
+     '/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/128F2EAF-6905-E811-810E-44A842BECCD8.root',
+    # Data
+    #'/store/data/Run2017B/Tau/MINIAOD/17Nov2017-v1/40000/02D49C45-F8DD-E711-9ACC-001E675043AD.root',
+    
     )
 )
 
@@ -118,7 +124,7 @@ process.source = cms.Source("PoolSource",
 #process.source.eventsToProcess = cms.untracked.VEventRange("1:2347130-1:2347130") # run only on event=2347130 (syntax= from run:evt - to run:evt)
 
 #Limited nEv for testing purposes. -1 to run all events
-process.maxEvents.input = 50 # FRA
+process.maxEvents.input = -1 # FRA
 
 # JSON mask for data --> defined in the lumiMask file
 # from JSON file
@@ -173,7 +179,7 @@ process.p = cms.Path(process.Candidates)
 
 # Silence output
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 1
+process.MessageLogger.cerr.FwkReport.reportEvery = 10
 #process.MessageLogger.categories.append('onlyError')
 #process.MessageLogger.cerr.onlyError=cms.untracked.PSet(threshold  = cms.untracked.string('ERROR'))
 #process.MessageLogger.cerr.threshold='ERROR'

--- a/NtupleProducer/test/datasets.txt
+++ b/NtupleProducer/test/datasets.txt
@@ -611,3 +611,16 @@
 /Tau/Run2017C-PromptReco-v3/MINIAOD
 /Tau/Run2017D-PromptReco-v1/MINIAOD
 
+
+=== EMBEDDED2017 ===
+/EmbeddingRun2017B/MuTauFinalState-imputDoubleMu_miniAOD-v1/USER
+/EmbeddingRun2017C/MuTauFinalState-imputDoubleMu_miniAOD-v1/USER
+/EmbeddingRun2017D/MuTauFinalState-imputDoubleMu_miniAOD-v1/USER
+
+/EmbeddingRun2017B/ElTauFinalState-imputDoubleMu_miniAOD-v1/USER 
+/EmbeddingRun2017C/ElTauFinalState-imputDoubleMu_miniAOD-v1/USER 
+/EmbeddingRun2017D/ElTauFinalState-imputDoubleMu_miniAOD-v1/USER 
+
+/EmbeddingRun2017B/TauTauFinalState-imputDoubleMu_miniAOD-v1/USER
+/EmbeddingRun2017C/TauTauFinalState-imputDoubleMu_miniAOD-v1/USER
+/EmbeddingRun2017D/TauTauFinalState-imputDoubleMu_miniAOD-v1/USER

--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ cmsenv
 # MVA EleID Fall 2017
 git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
 scram b -j 8
-
 cd $CMSSW_BASE/external
 # below, you may have a different architecture, this is just one example from lxplus (same on polui)
 cd slc6_amd64_gcc630/
@@ -264,8 +263,8 @@ cd slc6_amd64_gcc630/
 git clone https://github.com/lsoffi/RecoEgamma-ElectronIdentification.git data/RecoEgamma/ElectronIdentification/data
 cd data/RecoEgamma/ElectronIdentification/data
 git checkout CMSSW_9_4_0_pre3_TnP
-# Go back to the src/
-cd $CMSSW_BASE/srcbuildafter externalthe externalin 
+cd $CMSSW_BASE/src
+
 # Z-recoil corrections
 git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/RecoilCorrections
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ scram b -j 4
 ### Instructions for 92X
 
 ```
-cmsrel CMSSW_9_2_3_patch2
-cd CMSSW_9_2_3_patch2/src/
+cmsrel CMSSW_9_2_8
+cd CMSSW_9_2_8/src/
 cmsenv
 
 # Z-recoil corrections
@@ -255,7 +255,7 @@ git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/Recoil
 git clone https://github.com/LLRCMS/LLRHiggsTauTau
 cd LLRHiggsTauTau
 git checkout master
-git remote add my-LLR https://github.com/francescobrivio/LLRHiggsTauTau.git
+# git remote add my-LLR https://github.com/francescobrivio/LLRHiggsTauTau.git
 git checkout 92X
 cd -
 

--- a/README.md
+++ b/README.md
@@ -245,17 +245,33 @@ scram b -j 4
 ### Instructions for 92X
 
 ```
-cmsrel CMSSW_9_2_8
-cd CMSSW_9_2_8/src/
+cmsrel CMSSW_9_4_0
+cd CMSSW_9_4_0/src/
 cmsenv
 
+# MVA EleID Fall 2017
+git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
+scram b -j 8
+
+cd $CMSSW_BASE/external
+# below, you may have a different architecture, this is just one example from lxplus (same on polui)
+cd slc6_amd64_gcc630/
+git clone https://github.com/lsoffi/RecoEgamma-PhotonIdentification.git data/RecoEgamma/PhotonIdentification/data
+cd data/RecoEgamma/PhotonIdentification/data
+git checkout CMSSW_9_4_0_pre3_TnP
+cd $CMSSW_BASE/external
+cd slc6_amd64_gcc630/
+git clone https://github.com/lsoffi/RecoEgamma-ElectronIdentification.git data/RecoEgamma/ElectronIdentification/data
+cd data/RecoEgamma/ElectronIdentification/data
+git checkout CMSSW_9_4_0_pre3_TnP
+# Go back to the src/
+cd $CMSSW_BASE/srcbuildafter externalthe externalin 
 # Z-recoil corrections
 git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/RecoilCorrections
 
+# LLRHiggsTauTau framework
 git clone https://github.com/LLRCMS/LLRHiggsTauTau
 cd LLRHiggsTauTau
-git checkout master
-# git remote add my-LLR https://github.com/francescobrivio/LLRHiggsTauTau.git
 git checkout 92X
 cd -
 
@@ -285,6 +301,8 @@ git clone https://github.com/svfit/SVfitTF TauAnalysis/SVfitTF
 git clone git@github.com:veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
 cd TauAnalysis/SVfitStandalone
 git checkout HIG-16-006
+# need to fix: TauAnalysis/SVfitStandalone/src/SVfitStandaloneQuantities.cc 
+# add '#include <numeric>'
 
 cd $CMSSW_BASE/src
 scram b -j 8
@@ -292,4 +310,4 @@ scram b -j 8
 
 ### Quick usage:
 Define the files you want to run in analyzer.py and run cmsRun analyzer.py
-Please note that the MVA Spring 16 Electron ID is now available and used by default
+


### PR DESCRIPTION
Updates for 2017, tested for 94X
* VBF trigger matching
* pile up jet ID: https://twiki.cern.ch/twiki/bin/view/CMS/PileupJetID#Information_for_13_TeV_data_anal
* jet ID:  https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2017
* tau ID: https://twiki.cern.ch/twiki/bin/view/CMS/TauIDRecommendation13TeV#Isolation
* ele ID: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#Recommended_MVA_Recipe_for_regul
* triggers updated: DoubleTau, SingleEle, SingleMu 
* new triggers: VBF H TauTau, ETau, MuTau, Tau+MET 

Trigger documentation can be found in: 
* https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorking2017#Trigger_Information
* https://twiki.cern.ch/twiki/bin/view/CMS/TauTrigger#Trigger_table_for_2017
README updated