### PR TITLE
Trigger matching

### DIFF
--- a/NtupleProducer/interface/triggerMapper.h
+++ b/NtupleProducer/interface/triggerMapper.h
@@ -31,6 +31,7 @@ class triggerMapper {
   triggerMapper(string, std::vector<std::string>,std::vector<std::string>, int);
   triggerMapper(string, std::vector<std::string>,std::vector<std::string>, int theleg1ID, int theleg2ID);
   triggerMapper(string, std::vector<std::string>,std::vector<std::string>, std::vector<std::string>, std::vector<std::string>, int theleg1ID, int theleg2ID); //FRA
+  triggerMapper(string, std::vector<std::string>,std::vector<std::string>, std::vector<std::string>, std::vector<std::string>, int theleg1ID, int theleg2ID, double, double); //FRA
   //triggerMapper(TString, TString*,TString*,int,int);
   triggerMapper(string, string, string, int);
   
@@ -41,6 +42,8 @@ class triggerMapper {
   int GetNfiltersleg4(){return filter_leg4.size();} //FRA
   string Getfilter(bool isleg1, int iFilter);
   string GetfilterVBF(bool isleg3, int iFilter); //FRA
+  double GetPtCut1() {return pt1;} //FRA
+  double GetPtCut2() {return pt2;} //FRA
   std::vector<std::string> Getfilters(bool isleg1){return (isleg1 ? filter_leg1 : filter_leg2); };
   int GetTriggerChannel(){return channel;}
   pair <int, int> GetTriggerLegsID(){return make_pair(leg1ID, leg2ID);}
@@ -55,7 +58,9 @@ class triggerMapper {
   std::vector<string> filter_leg3; //FRA
   std::vector<string> filter_leg4; //FRA
   int channel; // final decay channel: mu tau, ele tau, ...
-  int leg1ID; //  abs(pdgID) of leg 1
-  int leg2ID; //  abs(pdgID) of leg 2
+  int leg1ID;  // abs(pdgID) of leg 1
+  int leg2ID;  // abs(pdgID) of leg 2
+  double pt1;  // pT cut for leg1 //FRA
+  double pt2;  // pT cut for leg2 //FRA
 };
 #endif

--- a/NtupleProducer/interface/triggerhelper.h
+++ b/NtupleProducer/interface/triggerhelper.h
@@ -32,6 +32,7 @@ class triggerhelper {
   void addTriggerMap(string hlt,vector<string> path1, vector<string> path2, int channel);
   void addTriggerMap(string hlt,vector<string> path1, vector<string> path2, int leg1ID, int leg2ID);
   void addTriggerMap(string hlt,vector<string> path1, vector<string> path2, vector<string> path3, vector<string> path4, int leg1ID, int leg2ID); //FRA
+  void addTriggerMap(string hlt,vector<string> path1, vector<string> path2, vector<string> path3, vector<string> path4, int leg1ID, int leg2ID, double pt1, double pt2); //FRA
   Long64_t FindTriggerBit(const edm::Event&, const vector<string>, const vector<int>, const edm::Handle<edm::TriggerResults>& triggerResults);
   int FindMETBit(const edm::Event&, edm::EDGetTokenT<edm::TriggerResults> metFilterBitsToken);
   

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -733,9 +733,12 @@ HTauTauNtuplizer::HTauTauNtuplizer(const edm::ParameterSet& pset) : reweight(),
     const std::vector<std::string>& path4 = iPSet->getParameter<std::vector<std::string>>("path4"); //FRA
     const int& leg1 = iPSet->getParameter<int>("leg1");
     const int& leg2 = iPSet->getParameter<int>("leg2");
+    const double& pt1 = iPSet->getParameter<double>("pt1"); //FRA
+    const double& pt2 = iPSet->getParameter<double>("pt2"); //FRA
     // Build the mape
     //myTriggerHelper->addTriggerMap(hlt,path1,path2,leg1,leg2);
-    myTriggerHelper->addTriggerMap(hlt,path1,path2,path3,path4,leg1,leg2); //FRA
+    //myTriggerHelper->addTriggerMap(hlt,path1,path2,path3,path4,leg1,leg2); //FRA
+    myTriggerHelper->addTriggerMap(hlt,path1,path2,path3,path4,leg1,leg2, pt1, pt2); //FRA
   }
 
   //triggerSet= pset.getParameter<edm::InputTag>("triggerSet");
@@ -2821,7 +2824,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     for (size_t idxto = 0; idxto < triggerObjects->size(); ++idxto)
     {
       pat::TriggerObjectStandAlone obj = triggerObjects->at(idxto);
-      
+
       // unpacking Filter Labels
       obj.unpackFilterLabels(event,*triggerBits); //FRA
       
@@ -2875,7 +2878,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
             }
           }
           else isfilterGood = false;
-
+          
           //_isFilterFiredLast;
           if(isfilterGood)filterFired |= long(1) <<triggerbit;
           if(triggerType) triggertypeIsGood |= long(1) << triggerbit;
@@ -2889,6 +2892,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
         for (int triggerbit = 0; triggerbit < myTriggerHelper->GetNTriggers(); ++triggerbit)
         {
           triggerMapper trgmap = myTriggerHelper->GetTriggerMap(triggerbit);
+            
           bool istrgMatched = true;
           int IDsearch = 0;
           if (type==ParticleType::ELECTRON)  IDsearch = 11;
@@ -2923,6 +2927,20 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
             }
           }
           else istrgMatched = false;
+          
+          // Check the pT of the candidate for leg1 and 2 //FRA
+          if (legPosition == 1)
+          {
+            if ( cand->pt() < trgmap.GetPtCut1() ) istrgMatched=false;
+          }
+          else if (legPosition == 2)
+          {
+            if ( cand->pt() < trgmap.GetPtCut2() ) istrgMatched=false;
+          }
+          else
+            istrgMatched=false;
+          
+          
           // FIXME: should I check type? --> no, multiple filters should be enough
           if(istrgMatched)
           {

--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -20,7 +20,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
+        leg2 = cms.int32(999),
+        pt1 = cms.double(29),
+        pt2 = cms.double(-999)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu24_v"), # ---------- it's prescaled: TO BE REMOVED
@@ -29,7 +31,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(999)
+        leg2 = cms.int32(999),
+        pt1 = cms.double(26),
+        pt2 = cms.double(-999)
         ),
 ### === Single electron triggers - OK
     cms.PSet (
@@ -39,7 +43,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
-        leg2 = cms.int32(999)
+        leg2 = cms.int32(999),
+        pt1 = cms.double(35),
+        pt2 = cms.double(-999)
         ),
     cms.PSet (
         HLT = cms.string("HLT_Ele35_WPTight_Gsf_v"),
@@ -48,7 +54,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
-        leg2 = cms.int32(999)
+        leg2 = cms.int32(999),
+        pt1 = cms.double(38),
+        pt2 = cms.double(-999)
         ),
 ### === mu tauh triggers - OK
     cms.PSet (
@@ -58,7 +66,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(22),
+        pt2 = cms.double(32)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu20_eta2p1_MediumChargedIsoPFTau27_eta2p1_CrossL1_v"),
@@ -67,7 +77,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(22),
+        pt2 = cms.double(32)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu20_eta2p1_TightChargedIsoPFTau27_eta2p1_CrossL1_v"),
@@ -76,7 +88,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(22),
+        pt2 = cms.double(32)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_TightID_CrossL1_v"),
@@ -85,7 +99,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(22),
+        pt2 = cms.double(32)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu20_eta2p1_MediumChargedIsoPFTau27_eta2p1_TightID_CrossL1_v"),
@@ -94,7 +110,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(22),
+        pt2 = cms.double(32)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu20_eta2p1_TightChargedIsoPFTau27_eta2p1_TightID_CrossL1_v"),
@@ -103,7 +121,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(22),
+        pt2 = cms.double(32)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_eta2p1_SingleL1_v"),
@@ -112,7 +132,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(26),
+        pt2 = cms.double(25)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau20_eta2p1_SingleL1_v"),
@@ -121,7 +143,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(26),
+        pt2 = cms.double(25)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTau20_eta2p1_SingleL1_v"),
@@ -130,7 +154,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(26),
+        pt2 = cms.double(25)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_eta2p1_TightID_SingleL1_v"),
@@ -139,7 +165,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(26),
+        pt2 = cms.double(25)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau20_eta2p1_TightID_SingleL1_v"),
@@ -148,7 +176,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(26),
+        pt2 = cms.double(25)
         ),
     cms.PSet (
         HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTau20_eta2p1_TightID_SingleL1_v"),
@@ -157,7 +187,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(13),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(26),
+        pt2 = cms.double(25)
         ),
 ### === ele tauh triggers - OK
     cms.PSet (
@@ -167,7 +199,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(27),
+        pt2 = cms.double(35)
         ),
     cms.PSet (
         HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_MediumChargedIsoPFTau30_eta2p1_CrossL1_v"),
@@ -176,7 +210,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(27),
+        pt2 = cms.double(35)
         ),
     cms.PSet (
         HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_TightChargedIsoPFTau30_eta2p1_CrossL1_v"),
@@ -185,7 +221,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(27),
+        pt2 = cms.double(35)
         ),
     cms.PSet (
         HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_TightID_CrossL1_v"),
@@ -194,7 +232,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(27),
+        pt2 = cms.double(35)
         ),
     cms.PSet (
         HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_MediumChargedIsoPFTau30_eta2p1_TightID_CrossL1_v"),
@@ -203,7 +243,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(27),
+        pt2 = cms.double(35)
         ),
     cms.PSet (
         HLT = cms.string("HLT_Ele24_eta2p1_WPTight_Gsf_TightChargedIsoPFTau30_eta2p1_TightID_CrossL1_v"),
@@ -212,7 +254,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(27),
+        pt2 = cms.double(35)
         ),
 ### === tauh tauh triggers - OK
     cms.PSet (
@@ -222,7 +266,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(40),
+        pt2 = cms.double(40)
         ),
     cms.PSet (
         HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v"),
@@ -231,7 +277,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(40),
+        pt2 = cms.double(40)
         ),
     cms.PSet (
         HLT = cms.string("HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v"),
@@ -240,7 +288,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(40),
+        pt2 = cms.double(40)
         ),
     cms.PSet (
         HLT = cms.string("HLT_DoubleTightChargedIsoPFTau35_Trk1_eta2p1_Reg_v"),
@@ -249,7 +299,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(40),
+        pt2 = cms.double(40)
         ),
     cms.PSet (
         HLT = cms.string("HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v"),
@@ -258,7 +310,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(45),
+        pt2 = cms.double(45)
         ),
     cms.PSet (
         HLT = cms.string("HLT_DoubleTightChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v"),
@@ -267,7 +321,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(45),
+        pt2 = cms.double(45)
         ),
     cms.PSet (
         HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v"),
@@ -276,7 +332,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(45),
+        pt2 = cms.double(45)
         ),
     cms.PSet (
         HLT = cms.string("HLT_DoubleMediumChargedIsoPFTau40_Trk1_eta2p1_Reg_v"),
@@ -285,7 +343,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(45),
+        pt2 = cms.double(45)
         ),
 # ### === ele mu triggers -- TO BE DONE
 #     cms.PSet (
@@ -401,7 +461,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
+        leg2 = cms.int32(999),
+        pt1 = cms.double(185),
+        pt2 = cms.double(-999)
         ),
     cms.PSet (
         HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v"), # Do we need this?? probably not...
@@ -410,7 +472,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
+        leg2 = cms.int32(999),
+        pt1 = cms.double(185),
+        pt2 = cms.double(-999)
         ),
 ## === VBF + double-tau triggers
     cms.PSet (
@@ -420,7 +484,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTau20"), # 2 jets with pt>40
         path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20"),  # 1 jet with pt>115
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(25),
+        pt2 = cms.double(25)
         ),
     cms.PSet (
         HLT = cms.string("HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
@@ -429,7 +495,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumChargedIsoPFTau20"), # 2 jets with pt>40
         path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumChargedIsoPFTau20"),  # 1 jet with pt>115
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(25),
+        pt2 = cms.double(25)
         ),
     cms.PSet (
         HLT = cms.string("HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v"),
@@ -438,7 +506,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring ("hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleTightChargedIsoPFTau20"), # 2 jets with pt>40
         path4 = cms.vstring ("hltMatchedVBFOnePFJet2CrossCleanedFromDoubleTightChargedIsoPFTau20"),  # 1 jet with pt>115
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(25),
+        pt2 = cms.double(25)
         ),
 ## === Tau + MET
     cms.PSet (
@@ -448,7 +518,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(55),
+        pt2 = cms.double(-999)
         ),
     cms.PSet (
         HLT = cms.string("HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET100_v"),
@@ -457,7 +529,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(55),
+        pt2 = cms.double(-999)
         ),
     cms.PSet (
         HLT = cms.string("HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET110_v"),
@@ -466,7 +540,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(55),
+        pt2 = cms.double(-999)
         ),
     cms.PSet (
         HLT = cms.string("HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET130_v"),
@@ -475,7 +551,9 @@ HLTLIST = cms.VPSet(
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
         leg1 = cms.int32(15),
-        leg2 = cms.int32(15)
+        leg2 = cms.int32(15),
+        pt1 = cms.double(55),
+        pt2 = cms.double(-999)
         ),
 ## === 4 jets (for VBF) # FILTERS TO BE FIXED
     #cms.PSet (

--- a/NtupleProducer/src/triggerMapper.cc
+++ b/NtupleProducer/src/triggerMapper.cc
@@ -39,6 +39,8 @@ triggerMapper::triggerMapper(const triggerMapper& trigMap)
   channel = trigMap.channel;
   leg1ID = trigMap.leg1ID;
   leg2ID = trigMap.leg2ID;
+  pt1 = trigMap.pt1; //FRA
+  pt2 = trigMap.pt2; //FRA
 }
 
 
@@ -133,7 +135,35 @@ triggerMapper::triggerMapper(string HLTtrigger, std::vector<std::string> filters
   else if (leg1ID == (int) kmu  && leg2ID == (int) kmu)  channel = (int) kmumu;
   else if (leg1ID == (int) kele && leg2ID == (int) kele) channel = (int) kee;
   else channel = 999;
+}
 
+//FRA : adding cuts on tau pt
+triggerMapper::triggerMapper(string HLTtrigger, std::vector<std::string> filters1, std::vector<std::string> filters2, std::vector<std::string> filters3, std::vector<std::string> filters4, int theleg1ID, int theleg2ID, double thept1, double thept2)
+{
+  HLT=HLTtrigger;
+  int n1 = filters1.size();
+  int n2 = filters2.size();
+  int n3 = filters3.size();
+  int n4 = filters4.size();
+    
+  for(int i=0;i<n1;i++){filter_leg1.push_back(filters1.at(i));}
+  for(int i=0;i<n2;i++){filter_leg2.push_back(filters2.at(i));}
+  for(int i=0;i<n3;i++){filter_leg3.push_back(filters3.at(i));}
+  for(int i=0;i<n4;i++){filter_leg4.push_back(filters4.at(i));}
+
+  leg1ID = theleg1ID;
+  leg2ID = theleg2ID;
+
+  if      (leg1ID == (int) kele && leg2ID == (int) kmu)  channel = (int) kemu;
+  else if (leg1ID == (int) kele && leg2ID == (int) ktau) channel = (int) ketau;
+  else if (leg1ID == (int) kmu  && leg2ID == (int) ktau) channel = (int) kmutau;
+  else if (leg1ID == (int) ktau && leg2ID == (int) ktau) channel = (int) ktautau;
+  else if (leg1ID == (int) kmu  && leg2ID == (int) kmu)  channel = (int) kmumu;
+  else if (leg1ID == (int) kele && leg2ID == (int) kele) channel = (int) kee;
+  else channel = 999;
+  
+  pt1 = thept1;
+  pt2 = thept2;
 }
 
 triggerMapper::triggerMapper(string HLTtrigger, string filter1, string filter2, int c){
@@ -199,6 +229,7 @@ string triggerMapper::Getfilter(bool isleg1,int iFilter){
   return result;
 }
 
+// FRA
 string triggerMapper::GetfilterVBF(bool isleg3,int iFilter){
   string result("");
   if(isleg3){

--- a/NtupleProducer/src/triggerhelper.cc
+++ b/NtupleProducer/src/triggerhelper.cc
@@ -158,6 +158,20 @@ void triggerhelper::addTriggerMap(string hlt,vector<string> path1, vector<string
   triggerMap.push_back(map);
 }
 
+//FRA : added pt cuts for leg1 and leg2
+void triggerhelper::addTriggerMap(string hlt,vector<string> path1, vector<string> path2, vector<string> path3, vector<string> path4, int leg1ID, int leg2ID, double pt1, double pt2)
+{
+
+  if (find(triggerlist.begin(), triggerlist.end(), hlt) != triggerlist.end() )
+  {
+    cout << "** triggerHelper :: Warning: path " << hlt << " already added, skipping" << endl;
+    return;
+  }
+  
+  triggerlist.push_back(hlt);
+  triggerMapper map(hlt, path1, path2, path3, path4, leg1ID, leg2ID, pt1, pt2);
+  triggerMap.push_back(map);
+}
 
 Long64_t triggerhelper::FindTriggerBit(const edm::Event& event, const vector<string> foundPaths, const vector<int> indexOfPaths, const edm::Handle<edm::TriggerResults>& triggerResults){
   

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -27,7 +27,7 @@ SVFITBYPASS=True # use SVFitBypass module, no SVfit computation, adds dummy user
 USECLASSICSVFIT=True # if True use the ClassicSVfit package, if False use the SVFitStandAlone package
 
 BUILDONLYOS=False #If true don't create the collection of SS candidates (and thus don't run SV fit on them)
-APPLYTESCORRECTION=True # shift the central value of the tau energy scale before computing up/down variations
+APPLYTESCORRECTION=False # shift the central value of the tau energy scale before computing up/down variations
 COMPUTEUPDOWNSVFIT=False # compute SVfit for up/down TES variation
 doCPVariables=False # compute CP variables and PV refit
 COMPUTEQGVAR = False # compute QG Tagger for jets

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -41,9 +41,9 @@ print "HLTProcessName: ",HLTProcessName
 #relaxed sets for testing purposes
 TAUDISCRIMINATOR="byIsolationMVA3oldDMwoLTraw"
 PVERTEXCUT="!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2" #cut on good primary vertexes
-MUCUT="isLooseMuon && pt>5"
-ELECUT="pt>7"#"gsfTrack.hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS)<=1 && pt>10"
-TAUCUT="tauID('byCombinedIsolationDeltaBetaCorrRaw3Hits') < 1000.0 && pt>18" #miniAOD tau from hpsPFTauProducer have pt>18 and decaymodefinding ID
+MUCUT="isLooseMuon && pt>10"#"isLooseMuon && pt>5"
+ELECUT="pt>10"#"pt>7"#"gsfTracsk.hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS)<=1 && pt>10"
+TAUCUT="pt>20"#"tauID('byCombinedIsolationDeltaBetaCorrRaw3Hits') < 1000.0 && pt>18" #miniAOD tau from hpsPFTauProducer have pt>18 and decaymodefinding ID
 JETCUT="pt>10"
 LLCUT="mass>-99999"
 BCUT="pt>5"

--- a/NtupleProducer/test/datasets_Fall17.txt
+++ b/NtupleProducer/test/datasets_Fall17.txt
@@ -52,7 +52,7 @@ https://cms-pdmv.cern.ch/mcm/requests?dataset_name=*WWTo*13TeV*&prepid=*Fall17*M
 ## TT
 /TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v2/MINIAODSIM
 /TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v1/MINIAODSIM
-#/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v1/MINIAODSIM
+/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v1/MINIAODSIM
 
 ## Single T
 /ST_t-channel_antitop_4f_inclusiveDecays_TuneCP5_13TeV-powhegV2-madspin-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v1/MINIAODSIM
@@ -85,7 +85,7 @@ https://cms-pdmv.cern.ch/mcm/requests?dataset_name=*WWTo*13TeV*&prepid=*Fall17*M
 ## EWKW
 /EWKWMinus2Jets_WToLNu_M-50_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v2/MINIAODSIM
 /EWKZ2Jets_ZToLL_M-50_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v2/MINIAODSIM
-#/EWKWPlus2Jets_WToLNu_M-50_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v3/MINIAODSIM
+/EWKWPlus2Jets_WToLNu_M-50_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v3/MINIAODSIM
 #/EWKWPlus2Jets_WToLNu_M-50_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAOD-94X_mc2017_realistic_v10-v2/MINIAODSIM
 
 ## VV


### PR DESCRIPTION
Added cuts on tau pt (both leg1 and leg2) when doing trigger matching.
The candidate pt must be higher that the HLT pt threshold + a safety shift to avoid 
the HLT efficiency turn on. (eg. HLT_isoMU24 -> candidate.pt() > 24+2 ).

Updated triggers_92X.py with the new pt thresholds. Chosen values: 3GeV for electron,
2 GeV for muons, 5 GeV for taus.

In analyzer.py:
- TES correction disabled in analyzer.py
- fixed ELECUT, MUCUT and TAUCUT for 2018