### PR TITLE
SVfit + shifted MET

### DIFF
--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -387,50 +387,74 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _SVmass;
   std::vector<Float_t> _SVmassTauUp;
   std::vector<Float_t> _SVmassTauDown;
+  std::vector<Float_t> _SVmassMETUp;
+  std::vector<Float_t> _SVmassMETDown;
 
   std::vector<Float_t> _SVmassUnc;
   std::vector<Float_t> _SVmassUncTauUp;
   std::vector<Float_t> _SVmassUncTauDown;
+  std::vector<Float_t> _SVmassUncMETUp;
+  std::vector<Float_t> _SVmassUncMETDown;
 
   std::vector<Float_t> _SVmassTransverse;
   std::vector<Float_t> _SVmassTransverseTauUp;
   std::vector<Float_t> _SVmassTransverseTauDown;
+  std::vector<Float_t> _SVmassTransverseMETUp;
+  std::vector<Float_t> _SVmassTransverseMETDown;
 
   std::vector<Float_t> _SVmassTransverseUnc;
   std::vector<Float_t> _SVmassTransverseUncTauUp;
   std::vector<Float_t> _SVmassTransverseUncTauDown;
+  std::vector<Float_t> _SVmassTransverseUncMETUp;
+  std::vector<Float_t> _SVmassTransverseUncMETDown;
 
   std::vector<Float_t> _SVpt;
   std::vector<Float_t> _SVptTauUp;
   std::vector<Float_t> _SVptTauDown;
+  std::vector<Float_t> _SVptMETUp;
+  std::vector<Float_t> _SVptMETDown;
 
   std::vector<Float_t> _SVptUnc;
   std::vector<Float_t> _SVptUncTauUp;
   std::vector<Float_t> _SVptUncTauDown;
+  std::vector<Float_t> _SVptUncMETUp;
+  std::vector<Float_t> _SVptUncMETDown;
 
   std::vector<Float_t> _SVeta;
   std::vector<Float_t> _SVetaTauUp;
   std::vector<Float_t> _SVetaTauDown;
+  std::vector<Float_t> _SVetaMETUp;
+  std::vector<Float_t> _SVetaMETDown;
 
   std::vector<Float_t> _SVetaUnc;
   std::vector<Float_t> _SVetaUncTauUp;
   std::vector<Float_t> _SVetaUncTauDown;
+  std::vector<Float_t> _SVetaUncMETUp;
+  std::vector<Float_t> _SVetaUncMETDown;
 
   std::vector<Float_t> _SVphi;
   std::vector<Float_t> _SVphiTauUp;
   std::vector<Float_t> _SVphiTauDown;
+  std::vector<Float_t> _SVphiMETUp;
+  std::vector<Float_t> _SVphiMETDown;
 
   std::vector<Float_t> _SVphiUnc;
   std::vector<Float_t> _SVphiUncTauUp;
   std::vector<Float_t> _SVphiUncTauDown;
+  std::vector<Float_t> _SVphiUncMETUp;
+  std::vector<Float_t> _SVphiUncMETDown;
 
   std::vector<Float_t> _SVMetRho;
   std::vector<Float_t> _SVMetRhoTauUp;
   std::vector<Float_t> _SVMetRhoTauDown;
+  std::vector<Float_t> _SVMetRhoMETUp;
+  std::vector<Float_t> _SVMetRhoMETDown;
 
   std::vector<Float_t> _SVMetPhi;
   std::vector<Float_t> _SVMetPhiTauUp;
   std::vector<Float_t> _SVMetPhiTauDown;
+  std::vector<Float_t> _SVMetPhiMETUp;
+  std::vector<Float_t> _SVMetPhiMETDown;
 
   std::vector<Float_t> _metx;
   std::vector<Float_t> _mety;
@@ -1053,50 +1077,74 @@ void HTauTauNtuplizer::Initialize(){
   _SVmass.clear();
   _SVmassTauUp.clear();
   _SVmassTauDown.clear();
+  _SVmassMETUp.clear();
+  _SVmassMETDown.clear();
 
   _SVmassUnc.clear();
   _SVmassUncTauUp.clear();
   _SVmassUncTauDown.clear();
+  _SVmassUncMETUp.clear();
+  _SVmassUncMETDown.clear();
 
   _SVmassTransverse.clear();
   _SVmassTransverseTauUp.clear();
   _SVmassTransverseTauDown.clear();
+  _SVmassTransverseMETUp.clear();
+  _SVmassTransverseMETDown.clear();
 
   _SVmassTransverseUnc.clear();
   _SVmassTransverseUncTauUp.clear();
   _SVmassTransverseUncTauDown.clear();
+  _SVmassTransverseUncMETUp.clear();
+  _SVmassTransverseUncMETDown.clear();
 
   _SVpt.clear();
   _SVptTauUp.clear();
   _SVptTauDown.clear();
+  _SVptMETUp.clear();
+  _SVptMETDown.clear();
 
   _SVptUnc.clear();
   _SVptUncTauUp.clear();
   _SVptUncTauDown.clear();
+  _SVptUncMETUp.clear();
+  _SVptUncMETDown.clear();
 
   _SVeta.clear();
   _SVetaTauUp.clear();
   _SVetaTauDown.clear();
+  _SVetaMETUp.clear();
+  _SVetaMETDown.clear();
 
   _SVetaUnc.clear();
   _SVetaUncTauUp.clear();
   _SVetaUncTauDown.clear();
+  _SVetaUncMETUp.clear();
+  _SVetaUncMETDown.clear();
 
   _SVphi.clear();
   _SVphiTauUp.clear();
   _SVphiTauDown.clear();
+  _SVphiMETUp.clear();
+  _SVphiMETDown.clear();
 
   _SVphiUnc.clear();
   _SVphiUncTauUp.clear();
   _SVphiUncTauDown.clear();
+  _SVphiUncMETUp.clear();
+  _SVphiUncMETDown.clear();
 
   _SVMetRho.clear();
   _SVMetRhoTauUp.clear();
   _SVMetRhoTauDown.clear();
+  _SVMetRhoMETUp.clear();
+  _SVMetRhoMETDown.clear();
 
   _SVMetPhi.clear();
   _SVMetPhiTauUp.clear();
   _SVMetPhiTauDown.clear();
+  _SVMetPhiMETUp.clear();
+  _SVMetPhiMETDown.clear();
 
   _isOSCand.clear();
   _daughters_HLTpt.clear();
@@ -1458,28 +1506,52 @@ void HTauTauNtuplizer::beginJob(){
     myTree->Branch("NUP", &_nup,"NUP/I");
     myTree->Branch("SVfit_fitMETPhiTauUp", &_SVMetPhiTauUp);
     myTree->Branch("SVfit_fitMETPhiTauDown", &_SVMetPhiTauDown);
+    myTree->Branch("SVfit_fitMETPhiMETUp", &_SVMetPhiMETUp);
+    myTree->Branch("SVfit_fitMETPhiMETDown", &_SVMetPhiMETDown);
     myTree->Branch("SVfit_fitMETRhoTauUp", &_SVMetRhoTauUp);
     myTree->Branch("SVfit_fitMETRhoTauDown", &_SVMetRhoTauDown);
+    myTree->Branch("SVfit_fitMETRhoMETUp", &_SVMetRhoMETUp);
+    myTree->Branch("SVfit_fitMETRhoMETDown", &_SVMetRhoMETDown);
     myTree->Branch("SVfit_phiUncTauUp", &_SVphiUncTauUp);
     myTree->Branch("SVfit_phiUncTauDown", &_SVphiUncTauDown);
+    myTree->Branch("SVfit_phiUncMETUp", &_SVphiUncMETUp);
+    myTree->Branch("SVfit_phiUncMETDown", &_SVphiUncMETDown);
     myTree->Branch("SVfit_phiTauUp", &_SVphiTauUp);
     myTree->Branch("SVfit_phiTauDown", &_SVphiTauDown);
+    myTree->Branch("SVfit_phiMETUp", &_SVphiMETUp);
+    myTree->Branch("SVfit_phiMETDown", &_SVphiMETDown);
     myTree->Branch("SVfit_etaUncTauUp", &_SVetaUncTauUp);
     myTree->Branch("SVfit_etaUncTauDown", &_SVetaUncTauDown);
+    myTree->Branch("SVfit_etaUncMETUp", &_SVetaUncMETUp);
+    myTree->Branch("SVfit_etaUncMETDown", &_SVetaUncMETDown);
     myTree->Branch("SVfit_etaTauUp", &_SVetaTauUp);
     myTree->Branch("SVfit_etaTauDown", &_SVetaTauDown);
+    myTree->Branch("SVfit_etaMETUp", &_SVetaMETUp);
+    myTree->Branch("SVfit_etaMETDown", &_SVetaMETDown);
     myTree->Branch("SVfit_ptUncTauUp", &_SVptUncTauUp);
     myTree->Branch("SVfit_ptUncTauDown", &_SVptUncTauDown);
+    myTree->Branch("SVfit_ptUncMETUp", &_SVptUncMETUp);
+    myTree->Branch("SVfit_ptUncMETDown", &_SVptUncMETDown);
     myTree->Branch("SVfit_ptTauUp", &_SVptTauUp);
     myTree->Branch("SVfit_ptTauDown", &_SVptTauDown);
+    myTree->Branch("SVfit_ptMETUp", &_SVptMETUp);
+    myTree->Branch("SVfit_ptMETDown", &_SVptMETDown);
     myTree->Branch("SVfitTransverseMassUncTauUp",&_SVmassTransverseUncTauUp);
     myTree->Branch("SVfitTransverseMassUncTauDown",&_SVmassTransverseUncTauDown);
+    myTree->Branch("SVfitTransverseMassUncMETUp",&_SVmassTransverseUncMETUp);
+    myTree->Branch("SVfitTransverseMassUncMETDown",&_SVmassTransverseUncMETDown);
     myTree->Branch("SVfitTransverseMassTauUp",&_SVmassTransverseTauUp);
     myTree->Branch("SVfitTransverseMassTauDown",&_SVmassTransverseTauDown);
+    myTree->Branch("SVfitTransverseMassMETUp",&_SVmassTransverseMETUp);
+    myTree->Branch("SVfitTransverseMassMETDown",&_SVmassTransverseMETDown);
     myTree->Branch("SVfitMassUncTauUp",&_SVmassUncTauUp);
     myTree->Branch("SVfitMassUncTauDown",&_SVmassUncTauDown);
+    myTree->Branch("SVfitMassUncMETUp",&_SVmassUncMETUp);
+    myTree->Branch("SVfitMassUncMETDown",&_SVmassUncMETDown);
     myTree->Branch("SVfitMassTauUp",&_SVmassTauUp);
     myTree->Branch("SVfitMassTauDown",&_SVmassTauDown);
+    myTree->Branch("SVfitMassMETUp",&_SVmassMETUp);
+    myTree->Branch("SVfitMassMETDown",&_SVmassMETDown);
   }// end if isMC
   //myTree->Branch("daughters2",&_daughter2);
 
@@ -2101,54 +2173,80 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
     
     bool hasUp   = cand.hasUserFloat ("SVfitMassTauUp");
     bool hasDown = cand.hasUserFloat ("SVfitMassTauDown");
+    bool hasMETUp   = cand.hasUserFloat ("SVfitMassMETUp");
+    bool hasMETDown = cand.hasUserFloat ("SVfitMassMETDown");
 
     _SVmass.push_back(cand.userFloat("SVfitMass"));
     _SVmassTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfitMassTauUp")   : -999. ));
     _SVmassTauDown.push_back( (hasDown ? cand.userFloat("SVfitMassTauDown") : -999. ));
+    _SVmassMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfitMassMETUp")   : -999. ));
+    _SVmassMETDown.push_back( (hasMETDown ? cand.userFloat("SVfitMassMETDown") : -999. ));
 
     _SVmassUnc.push_back(cand.userFloat("SVfitMassUnc"));
     _SVmassUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfitMassUncTauUp")   : -999. ));
     _SVmassUncTauDown.push_back( (hasDown ? cand.userFloat("SVfitMassUncTauDown") : -999. ));
+    _SVmassUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfitMassUncMETUp")   : -999. ));
+    _SVmassUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfitMassUncMETDown") : -999. ));
 
     _SVmassTransverse.push_back(cand.userFloat("SVfitTransverseMass"));
     _SVmassTransverseTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfitTransverseMassTauUp")  : -999. ));
     _SVmassTransverseTauDown.push_back( (hasDown ? cand.userFloat("SVfitTransverseMassTauDown"): -999. ));
+    _SVmassTransverseMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfitTransverseMassMETUp")  : -999. ));
+    _SVmassTransverseMETDown.push_back( (hasMETDown ? cand.userFloat("SVfitTransverseMassMETDown"): -999. ));
 
     _SVmassTransverseUnc.push_back(cand.userFloat("SVfitTransverseMassUnc"));
     _SVmassTransverseUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfitTransverseMassUncTauUp")  : -999. ));
     _SVmassTransverseUncTauDown.push_back( (hasDown ? cand.userFloat("SVfitTransverseMassUncTauDown"): -999. ));
+    _SVmassTransverseUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfitTransverseMassUncMETUp")  : -999. ));
+    _SVmassTransverseUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfitTransverseMassUncMETDown"): -999. ));
 
     _SVpt.push_back(cand.userFloat("SVfit_pt"));
     _SVptTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_ptTauUp")  : -999. ));
     _SVptTauDown.push_back( (hasDown ? cand.userFloat("SVfit_ptTauDown"): -999. ));
+    _SVptMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_ptMETUp")  : -999. ));
+    _SVptMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_ptMETDown"): -999. ));
 
     _SVptUnc.push_back(cand.userFloat("SVfit_ptUnc"));
     _SVptUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_ptUncTauUp")  : -999. ));
     _SVptUncTauDown.push_back( (hasDown ? cand.userFloat("SVfit_ptUncTauDown"): -999. ));
+    _SVptUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_ptUncMETUp")  : -999. ));
+    _SVptUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_ptUncMETDown"): -999. ));
 
     _SVeta.push_back(cand.userFloat("SVfit_eta"));
     _SVetaTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_etaTauUp")  : -999. ));
     _SVetaTauDown.push_back( (hasDown ? cand.userFloat("SVfit_etaTauDown"): -999. ));
+    _SVetaMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_etaMETUp")  : -999. ));
+    _SVetaMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_etaMETDown"): -999. ));
 
     _SVetaUnc.push_back(cand.userFloat("SVfit_etaUnc"));
     _SVetaUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_etaUncTauUp")  : -999. ));
     _SVetaUncTauDown.push_back( (hasDown ? cand.userFloat("SVfit_etaUncTauDown"): -999. ));
+    _SVetaUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_etaUncMETUp")  : -999. ));
+    _SVetaUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_etaUncMETDown"): -999. ));
 
     _SVphi.push_back(cand.userFloat("SVfit_phi"));
     _SVphiTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_phiTauUp")  : -999. ));
     _SVphiTauDown.push_back( (hasDown ? cand.userFloat("SVfit_phiTauDown"): -999. ));
+    _SVphiMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_phiMETUp")  : -999. ));
+    _SVphiMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_phiMETDown"): -999. ));
 
     _SVphiUnc.push_back(cand.userFloat("SVfit_phiUnc"));
     _SVphiUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_phiUncTauUp")  : -999. ));
     _SVphiUncTauDown.push_back( (hasDown ? cand.userFloat("SVfit_phiUncTauDown"): -999. ));
+    _SVphiUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_phiUncMETUp")  : -999. ));
+    _SVphiUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_phiUncMETDown"): -999. ));
 
     _SVMetRho.push_back(cand.userFloat("SVfit_METRho"));
     _SVMetRhoTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_METRhoTauUp")  : -999. ));
     _SVMetRhoTauDown.push_back( (hasDown ? cand.userFloat("SVfit_METRhoTauDown"): -999. ));
+    _SVMetRhoMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_METRhoMETUp")  : -999. ));
+    _SVMetRhoMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_METRhoMETDown"): -999. ));
 
     _SVMetPhi.push_back(cand.userFloat("SVfit_METPhi"));
     _SVMetPhiTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_METPhiTauUp")  : -999. ));
     _SVMetPhiTauDown.push_back( (hasDown ? cand.userFloat("SVfit_METPhiTauDown"): -999. ));
+    _SVMetPhiMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_METPhiMETUp")  : -999. ));
+    _SVMetPhiMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_METPhiMETDown"): -999. ));
 
     _metx.push_back(thisMETpx);
     _mety.push_back(thisMETpy);

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -434,6 +434,10 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
 
   std::vector<Float_t> _metx;
   std::vector<Float_t> _mety;
+  std::vector<Float_t> _metx_up;
+  std::vector<Float_t> _mety_up;
+  std::vector<Float_t> _metx_down;
+  std::vector<Float_t> _mety_down;
   std::vector<Float_t> _uncorrmetx;
   std::vector<Float_t> _uncorrmety;
   std::vector<Float_t> _metCov00;
@@ -1099,6 +1103,10 @@ void HTauTauNtuplizer::Initialize(){
   _daughters_isL1IsoTau28Matched.clear();
   _metx.clear();
   _mety.clear();
+  _metx_up.clear();
+  _mety_up.clear();
+  _metx_down.clear();
+  _mety_down.clear();
   _uncorrmetx.clear();
   _uncorrmety.clear();
   _metCov00.clear();
@@ -1490,6 +1498,10 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("isOSCand",&_isOSCand);
   myTree->Branch("METx",&_metx);
   myTree->Branch("METy",&_mety);
+  myTree->Branch("METx_UP",&_metx_up);
+  myTree->Branch("METy_UP",&_mety_up);
+  myTree->Branch("METx_DOWN",&_metx_down);
+  myTree->Branch("METy_DOWN",&_mety_down);
   myTree->Branch("uncorrMETx",&_uncorrmetx);
   myTree->Branch("uncorrMETy",&_uncorrmety);
   myTree->Branch("MET_cov00",&_metCov00);
@@ -2080,6 +2092,10 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
 
     float thisMETpx = cand.userFloat("MEt_px");
     float thisMETpy = cand.userFloat("MEt_py");
+    float thisMETpx_up = cand.userFloat("MEt_px_UP");
+    float thisMETpy_up = cand.userFloat("MEt_py_UP");
+    float thisMETpx_down = cand.userFloat("MEt_px_DOWN");
+    float thisMETpy_down = cand.userFloat("MEt_py_DOWN");
     float thisMETpx_uncorr = ( cand.hasUserFloat("uncorrMEt_px") ) ? cand.userFloat("uncorrMEt_px") : -999.;
     float thisMETpy_uncorr = ( cand.hasUserFloat("uncorrMEt_py") ) ? cand.userFloat("uncorrMEt_py") : -999.;
     
@@ -2135,7 +2151,11 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
     _SVMetPhiTauDown.push_back( (hasDown ? cand.userFloat("SVfit_METPhiTauDown"): -999. ));
 
     _metx.push_back(thisMETpx);
-    _mety.push_back(thisMETpy);    
+    _mety.push_back(thisMETpy);
+    _metx_up.push_back(thisMETpx_up);
+    _mety_up.push_back(thisMETpy_up);
+    _metx_down.push_back(thisMETpx_down);
+    _mety_down.push_back(thisMETpy_down);
     _uncorrmetx.push_back(thisMETpx_uncorr);
     _uncorrmety.push_back(thisMETpy_uncorr);
     _metCov00.push_back(cand.userFloat("MEt_cov00"));

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -744,6 +744,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _ak8jets_tau1; // subjettiness
   std::vector<Float_t> _ak8jets_tau2; // subjettiness
   std::vector<Float_t> _ak8jets_tau3; // subjettiness
+  std::vector<Float_t> _ak8jets_tau4; // subjettiness
   std::vector<Float_t> _ak8jets_CSV; // CSV score
   std::vector<Float_t> _ak8jets_deepCSV_probb; // CSV score
   std::vector<Float_t> _ak8jets_deepCSV_probbb; // CSV score
@@ -1342,6 +1343,7 @@ void HTauTauNtuplizer::Initialize(){
   _ak8jets_tau1.clear();
   _ak8jets_tau2.clear();
   _ak8jets_tau3.clear();
+  _ak8jets_tau4.clear();
   _ak8jets_CSV.clear();
   _ak8jets_deepCSV_probb.clear();
   _ak8jets_deepCSV_probbb.clear();
@@ -1795,6 +1797,7 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("ak8jets_tau1", &_ak8jets_tau1);
   myTree->Branch("ak8jets_tau2", &_ak8jets_tau2);
   myTree->Branch("ak8jets_tau3", &_ak8jets_tau3);
+  myTree->Branch("ak8jets_tau4", &_ak8jets_tau4);
   myTree->Branch("ak8jets_CSV", &_ak8jets_CSV);
   myTree->Branch("ak8jets_deepCSV_probb", &_ak8jets_deepCSV_probb);
   myTree->Branch("ak8jets_deepCSV_probbb", &_ak8jets_deepCSV_probbb);
@@ -2970,22 +2973,32 @@ void HTauTauNtuplizer::FillFatJet(const edm::View<pat::Jet>* fatjets, const edm:
       _ak8jets_py.push_back( (float) ijet->py());
       _ak8jets_pz.push_back( (float) ijet->pz());
       _ak8jets_e.push_back( (float) ijet->energy());    
-      _ak8jets_SoftDropMass.push_back (ijet->hasUserFloat("ak8PFJetsCHSSoftDropMass") ? ijet->userFloat("ak8PFJetsCHSSoftDropMass") : -999 );
-      _ak8jets_PrunedMass.push_back   (ijet->hasUserFloat("ak8PFJetsCHSPrunedMass")   ? ijet->userFloat("ak8PFJetsCHSPrunedMass")   : -999 );
-      _ak8jets_TrimmedMass.push_back  (ijet->hasUserFloat("ak8PFJetsCHSTrimmedMass")  ? ijet->userFloat("ak8PFJetsCHSTrimmedMass")  : -999 );
-      _ak8jets_FilteredMass.push_back (ijet->hasUserFloat("ak8PFJetsCHSFilteredMass") ? ijet->userFloat("ak8PFJetsCHSFilteredMass") : -999 );
-      _ak8jets_tau1.push_back         (ijet->hasUserFloat("NjettinessAK8:tau1")       ? ijet->userFloat("NjettinessAK8:tau1")       : -999 );
-      _ak8jets_tau2.push_back         (ijet->hasUserFloat("NjettinessAK8:tau2")       ? ijet->userFloat("NjettinessAK8:tau2")       : -999 );
-      _ak8jets_tau3.push_back         (ijet->hasUserFloat("NjettinessAK8:tau3")       ? ijet->userFloat("NjettinessAK8:tau3")       : -999 );
+      //_ak8jets_SoftDropMass.push_back (ijet->hasUserFloat("ak8PFJetsCHSSoftDropMass") ? ijet->userFloat("ak8PFJetsCHSSoftDropMass") : -999 );
+      //_ak8jets_PrunedMass.push_back   (ijet->hasUserFloat("ak8PFJetsCHSPrunedMass")   ? ijet->userFloat("ak8PFJetsCHSPrunedMass")   : -999 );
+      //_ak8jets_TrimmedMass.push_back  (ijet->hasUserFloat("ak8PFJetsCHSTrimmedMass")  ? ijet->userFloat("ak8PFJetsCHSTrimmedMass")  : -999 );
+      //_ak8jets_FilteredMass.push_back (ijet->hasUserFloat("ak8PFJetsCHSFilteredMass") ? ijet->userFloat("ak8PFJetsCHSFilteredMass") : -999 );
+      //_ak8jets_tau1.push_back         (ijet->hasUserFloat("NjettinessAK8:tau1")       ? ijet->userFloat("NjettinessAK8:tau1")       : -999 );
+      //_ak8jets_tau2.push_back         (ijet->hasUserFloat("NjettinessAK8:tau2")       ? ijet->userFloat("NjettinessAK8:tau2")       : -999 );
+      //_ak8jets_tau3.push_back         (ijet->hasUserFloat("NjettinessAK8:tau3")       ? ijet->userFloat("NjettinessAK8:tau3")       : -999 );
+      _ak8jets_SoftDropMass.push_back (ijet->hasUserFloat("ak8PFJetsPuppiSoftDropMass") ? ijet->userFloat("ak8PFJetsPuppiSoftDropMass") : -999 );
+      _ak8jets_PrunedMass.push_back   (ijet->hasUserFloat("ak8PFJetsPuppiPrunedMass")   ? ijet->userFloat("ak8PFJetsCHSValueMap:ak8PFJetsCHSPrunedMass")   : -999 );
+      _ak8jets_TrimmedMass.push_back  (ijet->hasUserFloat("ak8PFJetsPuppiTrimmedMass")  ? ijet->userFloat("ak8PFJetsPuppiTrimmedMass")  : -999 );
+      _ak8jets_FilteredMass.push_back (ijet->hasUserFloat("ak8PFJetsPuppiFilteredMass") ? ijet->userFloat("ak8PFJetsPuppiFilteredMass") : -999 );
+      _ak8jets_tau1.push_back         (ijet->hasUserFloat("NjettinessAK8Puppi:tau1")    ? ijet->userFloat("NjettinessAK8Puppi:tau1")    : -999 );
+      _ak8jets_tau2.push_back         (ijet->hasUserFloat("NjettinessAK8Puppi:tau2")    ? ijet->userFloat("NjettinessAK8Puppi:tau2")    : -999 );
+      _ak8jets_tau3.push_back         (ijet->hasUserFloat("NjettinessAK8Puppi:tau3")    ? ijet->userFloat("NjettinessAK8Puppi:tau3")    : -999 );
+      _ak8jets_tau4.push_back         (ijet->hasUserFloat("NjettinessAK8Puppi:tau4")    ? ijet->userFloat("NjettinessAK8Puppi:tau4")    : -999 );
       _ak8jets_CSV.push_back(ijet->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
       _ak8jets_deepCSV_probb.push_back(ijet->bDiscriminator("pfDeepCSVJetTags:probb"));
       _ak8jets_deepCSV_probbb.push_back(ijet->bDiscriminator("pfDeepCSVJetTags:probbb"));
 
       // store subjets for soft drop
       int nsubj = 0;
-      if (ijet->hasSubjets("SoftDrop"))
+      //if (ijet->hasSubjets("SoftDrop"))
+      if (ijet->hasSubjets("SoftDropPuppi"))
       {
-        pat::JetPtrCollection const & subj = ijet->subjets("SoftDrop");
+        //pat::JetPtrCollection const & subj = ijet->subjets("SoftDrop");
+        pat::JetPtrCollection const & subj = ijet->subjets("SoftDropPuppi");
         // cout << "============= IJET " << ijet - fatjets->begin() << " ============= " << endl;
         for (auto isubj = subj.begin(); isubj!=subj.end(); isubj++)
         {

--- a/NtupleProducer/python/HiggsTauTauProducer_94X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_94X.py
@@ -859,7 +859,8 @@ if USECLASSICSVFIT:
                                       srcCov     = cms.InputTag("METSignificance", "METCovariance"),
                                       usePairMET = cms.bool(USEPAIRMET),
                                       srcMET     = srcMETTag,
-                                      computeForUpDownTES = cms.bool(COMPUTEUPDOWNSVFIT if IsMC else False)
+                                      computeForUpDownTES = cms.bool(COMPUTEUPDOWNSVFIT if IsMC else False),
+                                      computeForUpDownMET = cms.bool(COMPUTEMETUPDOWNSVFIT if IsMC else False)
     )
 else:
     print "Using STANDALONE_SV_FIT"

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -24,15 +24,16 @@ APPLYMETCORR=False # flag to enable (True) and disable (False) Z-recoil correcti
 USE_NOHFMET = False # True to exclude HF and run on silver json
 
 
-SVFITBYPASS=True # use SVFitBypass module, no SVfit computation, adds dummy userfloats for MET and SVfit mass
+SVFITBYPASS=False # use SVFitBypass module, no SVfit computation, adds dummy userfloats for MET and SVfit mass
 USECLASSICSVFIT=True # if True use the ClassicSVfit package, if False use the SVFitStandAlone package
 
 BUILDONLYOS=False #If true don't create the collection of SS candidates (and thus don't run SV fit on them)
 APPLYTESCORRECTION=True # shift the central value of the tau energy scale before computing up/down variations
 COMPUTEUPDOWNSVFIT=False # compute SVfit for up/down TES variation
+COMPUTEMETUPDOWNSVFIT=False # compute SVfit for up/down MET JES variation
 doCPVariables=False # compute CP variables and PV refit
 COMPUTEQGVAR = False # compute QG Tagger for jets
-IsMC=True
+IsMC=False
 Is25ns=True
 HLTProcessName='HLT' #Different names possible, check e.g. at https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD.
 if not IsMC:
@@ -118,16 +119,24 @@ process.source = cms.Source("PoolSource",
     #'/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/128F2EAF-6905-E811-810E-44A842BECCD8.root',
     #'/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/F89C5A80-6905-E811-9A3F-FA163ED3ED08.root',
     #'/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/34715D6D-6905-E811-9843-44A842CFD5BE.root',
-    '/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/1CA54262-F442-E811-8262-0CC47A4D7694.root',
-    '/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/5ED78A31-7243-E811-8053-484D7E8DF09F.root',
-    '/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/8CDFDFC6-C542-E811-9360-848F69FBC12A.root',
-    '/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/A4C07038-AC42-E811-8A74-1418776375C9.root',
+    # miniAOD_v2
+    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/1CA54262-F442-E811-8262-0CC47A4D7694.root',
+    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/5ED78A31-7243-E811-8053-484D7E8DF09F.root',
+    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/8CDFDFC6-C542-E811-9360-848F69FBC12A.root',
+    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/A4C07038-AC42-E811-8A74-1418776375C9.root',
+
     # Data
     #'/store/data/Run2017B/Tau/MINIAOD/17Nov2017-v1/40000/02D49C45-F8DD-E711-9ACC-001E675043AD.root',
     #'/store/data/Run2017B/SingleMuon/MINIAOD/31Mar2018-v1/100000/001642F1-6638-E811-B4FA-0025905B857A.root',
+    # miniAOD_v2
+    #'/store/data/Run2017B/Tau/MINIAOD/31Mar2018-v1/00000/040B1CD3-9437-E811-8D93-A4BF01158FE0.root',
+    '/store/data/Run2017F/Tau/MINIAOD/31Mar2018-v1/00000/0089E8C0-1A37-E811-9E5C-008CFAC93D18.root',
+
     # TT Fully Hadronic
     #'/store/mc/RunIIFall17MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/047A883D-9618-E811-B3FB-7CD30AD09FDC.root',
     #'/store/mc/RunIIFall17MiniAODv2/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/20000/CA2359BE-6442-E811-A7C5-9CB654AEAE02.root'
+    # miniAOD_v2
+    #'/store/mc/RunIIFall17MiniAODv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/00000/0031EAB0-8442-E811-84DF-0025901AFB36.root',
     )
 )
 

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -24,7 +24,7 @@ APPLYMETCORR=False # flag to enable (True) and disable (False) Z-recoil correcti
 USE_NOHFMET = False # True to exclude HF and run on silver json
 
 
-SVFITBYPASS=False # use SVFitBypass module, no SVfit computation, adds dummy userfloats for MET and SVfit mass
+SVFITBYPASS=True # use SVFitBypass module, no SVfit computation, adds dummy userfloats for MET and SVfit mass
 USECLASSICSVFIT=True # if True use the ClassicSVfit package, if False use the SVFitStandAlone package
 
 BUILDONLYOS=False #If true don't create the collection of SS candidates (and thus don't run SV fit on them)
@@ -33,7 +33,7 @@ COMPUTEUPDOWNSVFIT=False # compute SVfit for up/down TES variation
 COMPUTEMETUPDOWNSVFIT=False # compute SVfit for up/down MET JES variation
 doCPVariables=False # compute CP variables and PV refit
 COMPUTEQGVAR = False # compute QG Tagger for jets
-IsMC=False
+IsMC=True
 Is25ns=True
 HLTProcessName='HLT' #Different names possible, check e.g. at https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD.
 if not IsMC:
@@ -120,17 +120,17 @@ process.source = cms.Source("PoolSource",
     #'/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/F89C5A80-6905-E811-9A3F-FA163ED3ED08.root',
     #'/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/34715D6D-6905-E811-9843-44A842CFD5BE.root',
     # miniAOD_v2
-    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/1CA54262-F442-E811-8262-0CC47A4D7694.root',
-    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/5ED78A31-7243-E811-8053-484D7E8DF09F.root',
-    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/8CDFDFC6-C542-E811-9360-848F69FBC12A.root',
-    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/A4C07038-AC42-E811-8A74-1418776375C9.root',
+    '/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/1CA54262-F442-E811-8262-0CC47A4D7694.root',
+    '/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/5ED78A31-7243-E811-8053-484D7E8DF09F.root',
+    '/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/8CDFDFC6-C542-E811-9360-848F69FBC12A.root',
+    '/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/A4C07038-AC42-E811-8A74-1418776375C9.root',
 
     # Data
     #'/store/data/Run2017B/Tau/MINIAOD/17Nov2017-v1/40000/02D49C45-F8DD-E711-9ACC-001E675043AD.root',
     #'/store/data/Run2017B/SingleMuon/MINIAOD/31Mar2018-v1/100000/001642F1-6638-E811-B4FA-0025905B857A.root',
     # miniAOD_v2
     #'/store/data/Run2017B/Tau/MINIAOD/31Mar2018-v1/00000/040B1CD3-9437-E811-8D93-A4BF01158FE0.root',
-    '/store/data/Run2017F/Tau/MINIAOD/31Mar2018-v1/00000/0089E8C0-1A37-E811-9E5C-008CFAC93D18.root',
+    #'/store/data/Run2017F/Tau/MINIAOD/31Mar2018-v1/00000/0089E8C0-1A37-E811-9E5C-008CFAC93D18.root',
 
     # TT Fully Hadronic
     #'/store/mc/RunIIFall17MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/047A883D-9618-E811-B3FB-7CD30AD09FDC.root',


### PR DESCRIPTION
Added the calculation of SVfit for the Up/Down case of MET shifted by JES: for now only in 
ClassicSVfit (to be added later in SVfitStandalone)
Also added branches for the shifted MET and the SVfit quantities with shifted MET.
A new flag (COMPUTEMETUPDOWNSVFIT) in the config is added to run (or not) the svfit for shifted MET.

Minor bug fixed in ClassicSVfitInterface.

