### PR TITLE
ready for production

### DIFF
--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -184,7 +184,8 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     double shiftP = 1.;
     double shiftMass = 1.;
     
-    if ( l.genJet() && deltaR(l.p4(), l.genJet()->p4()) < 0.2 /*0.5*/ && l.genJet()->pt() > 8. && ApplyTESCentralCorr)
+    //if ( l.genJet() && deltaR(l.p4(), l.genJet()->p4()) < 0.5 && l.genJet()->pt() > 8. && ApplyTESCentralCorr) // 2016 data
+    if ( l.genJet() && deltaR(l.p4(), l.genJet()->p4()) < 0.2 && l.genJet()->pt() > 15. && ApplyTESCentralCorr)   // 2017 data
     {
 
       //cout << "---- gen get pt: " << l.genJet()->pt() << endl;
@@ -234,7 +235,8 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     float udshiftP[2] = {1., 1.};
     float udshiftMass[2] = {1., 1.};
     bool isTESShifted = false;
-    if ( l.genJet() && deltaR(l.p4(), l.genJet()->p4()) < 0.2 /*0.5*/ && l.genJet()->pt() > 8. ) {
+    //if ( l.genJet() && deltaR(l.p4(), l.genJet()->p4()) < 0.5 && l.genJet()->pt() > 8.) { // 2016 data
+    if ( l.genJet() && deltaR(l.p4(), l.genJet()->p4()) < 0.2 && l.genJet()->pt() > 15.) { // 2017 data
 
       isTESShifted = true;
 

--- a/NtupleProducer/python/HiggsTauTauProducer_94X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_94X.py
@@ -187,7 +187,8 @@ process.noBadGlobalMuons = cms.Sequence(process.cloneGlobalMuonTagger + process.
 
 
 process.bareSoftMuons = cms.EDFilter("PATMuonRefSelector",
-    src = cms.InputTag("removeBadAndCloneGlobalMuons"),
+    #src = cms.InputTag("removeBadAndCloneGlobalMuons"), # input for 2016 data only
+    src = cms.InputTag("slimmedMuons"),
     cut = cms.string(MUCUT),
 #    Lowering pT cuts
 #    cut = cms.string("(isGlobalMuon || (isTrackerMuon && numberOfMatches>0)) &&" +
@@ -226,7 +227,7 @@ process.softMuons = cms.EDProducer("MuFiller",
 )
 
 # process.muons =  cms.Sequence(process.cleanedMu + process.bareSoftMuons+ process.softMuons)
-process.muons =  cms.Sequence(process.noBadGlobalMuons + process.bareSoftMuons+ process.softMuons)    
+process.muons =  cms.Sequence(process.noBadGlobalMuons + process.bareSoftMuons+ process.softMuons)
 
 ###
 ### Electrons


### PR DESCRIPTION
- removed badMuons veto (2016 data only): the module is still in the sequence since it's output is requested by the Ntuplizer, but the " bad muon veto" is actually disabled

 - fixed the cuts for gen match in TauFiller: from pt>8. to pt>15. 