### PR TITLE
fix bug in METCorrections module

### DIFF
--- a/NtupleProducer/python/HiggsTauTauProducer_94X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_94X.py
@@ -585,7 +585,7 @@ from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMet
 
 runMetCorAndUncFromMiniAOD (
         process,
-        isData = True, # false for MC
+        isData = (not IsMC),
         fixEE2017 = True,
         fixEE2017Params = {'userawPt': True, 'ptThreshold':50.0, 'minEtaThreshold':2.65, 'maxEtaThreshold': 3.139} ,
         postfix = "ModifiedMET"


### PR DESCRIPTION
Fix minor bug of the "isData" bool flag in METCorrections module in HiggsTauTauProducer_94X.py