### PR TITLE
TES shift added for tau DM=2 added

### DIFF
--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -203,7 +203,7 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         shiftP    = Shift1Pr;
         shiftMass = 1.;
       }
-      else if (l.decayMode()==1)  // 1prong+pi0
+      else if ( (l.decayMode()==1) || (l.decayMode()==2) )  // 1prong+pi0 or 1prong+2pi0
       {
         shiftP    = Shift1PrPi0;
         shiftMass = Shift1PrPi0;

--- a/NtupleProducer/test/crab3_template_mib.py
+++ b/NtupleProducer/test/crab3_template_mib.py
@@ -12,6 +12,7 @@ config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = 'analyzer.py' # to produce LLR ntuples or EnrichedMiniAOD according to the RunNtuplizer bool
 config.JobType.sendExternalFolder = True #Needed until the PR including the Spring16 ele MVA ID is integrated in CMSSW/cms-data.
 config.JobType.inputFiles=['JECUncertaintySources'] # FRA: adding to the sandobx the directory with JEC files (https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#How_are_the_inputFiles_handled_i)
+config.JobType.maxMemoryMB = 2500 #3000
 
 config.section_("Data")
 config.Data.inputDataset = '/my/precious/dataset'
@@ -22,10 +23,11 @@ config.Data.totalUnits = -1 #number of event
 config.Data.outLFNDirBase = '/store/user/lcadamur/HHNtuples/DefaultOutLFNDirBase'
 config.Data.publication = True
 config.Data.outputDatasetTag = 'DefaultPublishName'
+config.Data.allowNonValidInputDataset = True
 
 # to run on dedicated 2k cores
-config.section_("Debug")
-config.Debug.extraJDL = [ '+DESIRED_Sites="T3_IT_Opportunistic_hnsci"','+JOB_CMSSite="T3_IT_Opportunistic_hnsci"','+AccountingGroup="highprio.spiga"' ]
+#config.section_("Debug")
+#config.Debug.extraJDL = [ '+DESIRED_Sites="T3_IT_Opportunistic_hnsci"','+JOB_CMSSite="T3_IT_Opportunistic_hnsci"','+AccountingGroup="highprio.spiga"' ]
 
 
 config.section_("Site")

--- a/NtupleProducer/test/datasetsFall17_January2019.txt
+++ b/NtupleProducer/test/datasetsFall17_January2019.txt
@@ -87,6 +87,25 @@
 /TTZZ_TuneCP5_13TeV-madgraph-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM
 
 
+=== BACKGROUNDS_Fall2017_January2019_njobs ===
+/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM
+/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+/TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM
+
+=== BACKGROUNDS_Fall2017_January2019_lumis ===
+/DY4JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_v2_94X_mc2017_realistic_v14-v2/MINIAODSIM
+
+=== BACKGROUNDS_Fall2017_January2019_njobs2 ===
+/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM
+
+=== BACKGROUNDS_Fall2017_January2019_njobs3 ===
+/WZTo3LNu_0Jets_MLL-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/MINIAODSIM
+/WZTo3LNu_1Jets_MLL-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM
+/WZTo3LNu_2Jets_MLL-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM
+/WZTo3LNu_3Jets_MLL-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM
+/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+
+
 === SIG_Fall17_January2019 ===
 ##### GGF Graviton
 /GluGluToBulkGravitonToHHTo2B2Tau_M-250_narrow_13TeV-madgraph_correctedcfg/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM

--- a/NtupleProducer/test/submitAllDatasetOnCrab_mib.py
+++ b/NtupleProducer/test/submitAllDatasetOnCrab_mib.py
@@ -42,9 +42,30 @@ import re
 #tag = "Data2017BF_31Mar2018ReReco_17May2018"
 #datasetsFile = "datasets_Fall17_15May2018.txt"
 
-PROCESS = ["MINIAODFALL17v2"]
-tag = "MC_25June2018"
-datasetsFile = "datasets_Fall17_15May2018.txt"
+#PROCESS = ["MINIAODFALL17v2"]
+#tag = "MC_25June2018"
+#datasetsFile = "datasets_Fall17_15May2018.txt"
+
+#PROCESS = ["BACKGROUNDS_Fall2017_January2019"]
+#tag = "MC_bkg_25January2019"
+#datasetsFile = "datasetsFall17_January2019.txt"
+
+#PROCESS = ["BACKGROUNDS_Fall2017_January2019_njobs"]
+#tag = "MC_bkg_25January2019_njobs"
+#datasetsFile = "datasetsFall17_January2019.txt"
+
+#PROCESS = ["BACKGROUNDS_Fall2017_January2019_lumis"]
+#tag = "MC_bkg_25January2019_lumis"
+#datasetsFile = "datasetsFall17_January2019.txt"
+
+#PROCESS = ["BACKGROUNDS_Fall2017_January2019_njobs2"]
+#tag = "MC_bkg_25January2019_njobs2"
+#datasetsFile = "datasetsFall17_January2019.txt"
+
+PROCESS = ["BACKGROUNDS_Fall2017_January2019_njobs3"]
+tag = "MC_bkg_25January2019_njobs3"
+datasetsFile = "datasetsFall17_January2019.txt"
+
 
 isMC = True
 #twiki page with JSON files info https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmV2015Analysis


### PR DESCRIPTION
Added the TES shifts for tau DM=2 which is included in the old decay modes and
is treated exactly as tau DM=1.