### PR TITLE
Updates for 2018 data sample analysis on branch 102 X_HH

### DIFF
--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -623,6 +623,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _daughters_jetPtRatio;
   std::vector<Float_t> _daughters_jetBTagCSV;
   std::vector<Float_t> _daughters_jetBTagDeepCSV;
+  std::vector<Float_t> _daughters_jetBTagDeepFlavor;
 
 
   std::vector<Float_t> _daughters_pca_x;
@@ -778,6 +779,9 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _ak8jets_CSV; // CSV score
   std::vector<Float_t> _ak8jets_deepCSV_probb; // CSV score
   std::vector<Float_t> _ak8jets_deepCSV_probbb; // CSV score
+  std::vector<Float_t> _ak8jets_deepFlavor_probb; // Flavor score
+  std::vector<Float_t> _ak8jets_deepFlavor_probbb; // Flavor score
+  std::vector<Float_t> _ak8jets_deepFlavor_problepb; // Flavor score
   std::vector<Int_t>   _ak8jets_nsubjets;
 
   // subjets of ak8 -- store ALL subjets, and link them with an idx to the ak8 jet vectors
@@ -788,6 +792,9 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _subjets_CSV;
   std::vector<Float_t> _subjets_deepCSV_probb;
   std::vector<Float_t> _subjets_deepCSV_probbb;
+  std::vector<Float_t> _subjets_deepFlavor_probb;
+  std::vector<Float_t> _subjets_deepFlavor_probbb;
+  std::vector<Float_t> _subjets_deepFlavor_problepb;
   std::vector<Int_t>   _subjets_ak8MotherIdx;
 
   std::vector<Int_t> _jets_Flavour; // parton flavour
@@ -1032,6 +1039,7 @@ void HTauTauNtuplizer::Initialize(){
   _daughters_jetPtRatio.clear();
   _daughters_jetBTagCSV.clear();
   _daughters_jetBTagDeepCSV.clear();
+  _daughters_jetBTagDeepFlavor.clear();
 
 
   //_daughters_iseleBDT.clear(); //FRA January2019
@@ -1397,6 +1405,9 @@ void HTauTauNtuplizer::Initialize(){
   _ak8jets_CSV.clear();
   _ak8jets_deepCSV_probb.clear();
   _ak8jets_deepCSV_probbb.clear();
+  _ak8jets_deepFlavor_probb.clear();
+  _ak8jets_deepFlavor_probbb.clear();
+  _ak8jets_deepFlavor_problepb.clear();
   _ak8jets_nsubjets.clear();
 
   _subjets_px.clear();
@@ -1406,6 +1417,9 @@ void HTauTauNtuplizer::Initialize(){
   _subjets_CSV.clear();
   _subjets_deepCSV_probb.clear();
   _subjets_deepCSV_probbb.clear();
+  _subjets_deepFlavor_probb.clear();
+  _subjets_deepFlavor_probbb.clear();
+  _subjets_deepFlavor_problepb.clear();
   _subjets_ak8MotherIdx.clear();
 
 
@@ -1733,6 +1747,7 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("daughters_jetPtRatio",&_daughters_jetPtRatio);
   myTree->Branch("daughters_jetBTagCSV",&_daughters_jetBTagCSV);
   myTree->Branch("daughters_jetBTagDeepCSV",&_daughters_jetBTagDeepCSV);
+  myTree->Branch("daughters_jetBTagDeepFlavor",&_daughters_jetBTagDeepFlavor);
 
 
   if(doCPVariables){
@@ -1875,6 +1890,9 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("ak8jets_CSV", &_ak8jets_CSV);
   myTree->Branch("ak8jets_deepCSV_probb", &_ak8jets_deepCSV_probb);
   myTree->Branch("ak8jets_deepCSV_probbb", &_ak8jets_deepCSV_probbb);
+  myTree->Branch("ak8jets_deepFlavor_probb", &_ak8jets_deepFlavor_probb);
+  myTree->Branch("ak8jets_deepFlavor_probbb", &_ak8jets_deepFlavor_probbb);
+  myTree->Branch("ak8jets_deepFlavor_problepb", &_ak8jets_deepFlavor_problepb);
   myTree->Branch("ak8jets_nsubjets", &_ak8jets_nsubjets);
 
   myTree->Branch("subjets_px", &_subjets_px);
@@ -1884,6 +1902,9 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("subjets_CSV", &_subjets_CSV);
   myTree->Branch("subjets_deepCSV_probb", &_subjets_deepCSV_probb);
   myTree->Branch("subjets_deepCSV_probbb", &_subjets_deepCSV_probbb);
+  myTree->Branch("subjets_deepFlavor_probb", &_subjets_deepFlavor_probb);
+  myTree->Branch("subjets_deepFlavor_probbb", &_subjets_deepFlavor_probbb);
+  myTree->Branch("subjets_deepFlavor_problepb", &_subjets_deepFlavor_problepb);
   myTree->Branch("subjets_ak8MotherIdx", &_subjets_ak8MotherIdx);
 
   if (doCPVariables) //FRA January2019
@@ -3070,6 +3091,9 @@ void HTauTauNtuplizer::FillFatJet(const edm::View<pat::Jet>* fatjets, const edm:
       _ak8jets_CSV.push_back(ijet->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
       _ak8jets_deepCSV_probb.push_back(ijet->bDiscriminator("pfDeepCSVJetTags:probb"));
       _ak8jets_deepCSV_probbb.push_back(ijet->bDiscriminator("pfDeepCSVJetTags:probbb"));
+      _ak8jets_deepFlavor_probb.push_back(ijet->bDiscriminator("pfDeepFlavourJetTags:probb"));
+      _ak8jets_deepFlavor_probbb.push_back(ijet->bDiscriminator("pfDeepFlavourJetTags:probbb"));
+      _ak8jets_deepFlavor_problepb.push_back(ijet->bDiscriminator("pfDeepFlavourJetTags:problepb"));
 
       // store subjets for soft drop
       int nsubj = 0;
@@ -3089,6 +3113,9 @@ void HTauTauNtuplizer::FillFatJet(const edm::View<pat::Jet>* fatjets, const edm:
           _subjets_CSV.push_back((*isubj)->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
           _subjets_deepCSV_probb.push_back((*isubj)->bDiscriminator("pfDeepCSVJetTags:probb"));
           _subjets_deepCSV_probbb.push_back((*isubj)->bDiscriminator("pfDeepCSVJetTags:probbb"));
+          _subjets_deepFlavor_probb.push_back((*isubj)->bDiscriminator("pfDeepFlavourJetTags:probb"));
+          _subjets_deepFlavor_probbb.push_back((*isubj)->bDiscriminator("pfDeepFlavourJetTags:probbb"));
+          _subjets_deepFlavor_problepb.push_back((*isubj)->bDiscriminator("pfDeepFlavourJetTags:problepb"));
           _subjets_ak8MotherIdx.push_back(ijet - fatjets->begin()); // idx of fatjet in fatjet vector
           // cout << " * " << (*isubj)->pt() << " " << isubj - subj.begin() << endl;
         }
@@ -3272,7 +3299,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     float dxy_innerTrack = -1., dz_innerTrack = -1., sip = -1., error_trackpt=-1.;
     int jetNDauChargedMVASel = -1;
     float miniRelIsoCharged = -1., miniRelIsoNeutral = -1.;
-    float jetPtRel = -1., jetPtRatio = -1., jetBTagCSV=-1., jetBTagDeepCSV=-1.;
+    float jetPtRel = -1., jetPtRatio = -1., jetBTagCSV=-1., jetBTagDeepCSV=-1., jetBTagDeepFlavor=-1.;
 
 
     //
@@ -3309,6 +3336,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
       jetPtRatio = LeptonIsoHelper::jetPtRatio(*cand, closest_jet,theJECName);
       jetBTagCSV = closest_jet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
       jetBTagDeepCSV = closest_jet.bDiscriminator("pfDeepCSVJetTags:probb") + closest_jet.bDiscriminator("pfDeepCSVJetTags:probbb");
+      jetBTagDeepFlavor = closest_jet.bDiscriminator("pfDeepFlavourJetTags:probb") + closest_jet.bDiscriminator("pfDeepFlavourJetTags:probbb") + closest_jet.bDiscriminator("pfDeepFlavourJetTags:problepb");
 
      
 
@@ -3346,6 +3374,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
       jetPtRatio = LeptonIsoHelper::jetPtRatio(*cand, closest_jet,theJECName);
       jetBTagCSV = closest_jet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
       jetBTagDeepCSV = closest_jet.bDiscriminator("pfDeepCSVJetTags:probb") + closest_jet.bDiscriminator("pfDeepCSVJetTags:probbb");
+      jetBTagDeepFlavor = closest_jet.bDiscriminator("pfDeepFlavourJetTags:probb") + closest_jet.bDiscriminator("pfDeepFlavourJetTags:probbb") + closest_jet.bDiscriminator("pfDeepFlavourJetTags:problepb");
 
 
 
@@ -3469,6 +3498,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     _daughters_jetPtRatio.push_back(jetPtRatio);
     _daughters_jetBTagCSV.push_back(jetBTagCSV);
     _daughters_jetBTagDeepCSV.push_back(jetBTagDeepCSV);
+    _daughters_jetBTagDeepFlavor.push_back(jetBTagDeepFlavor);
 
 
     _daughters_pca_x.push_back(pcaPV.X());

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -308,12 +308,12 @@ process.softTaus = cms.EDProducer("TauFiller",
    # --> Correct values for 2018 data - Davide update May2019
    NominalTESUncertainty1Pr         = cms.double(1.1) , # in percent, up/down uncertainty of TES      
    NominalTESUncertainty1PrPi0      = cms.double(0.9) , # in percent, up/down uncertainty of TES      
-   NominalTESUncertainty3Pr         = cms.double(0.9) , # in percent, up/down uncertainty of TES      
-   NominalTESUncertainty3PrPi0      = cms.double(1.0) , # in percent, up/down uncertainty of TES -- Missing for 2018      
+   NominalTESUncertainty3Pr         = cms.double(0.8) , # in percent, up/down uncertainty of TES      
+   NominalTESUncertainty3PrPi0      = cms.double(1.0) , # in percent, up/down uncertainty of TES -- Missing for 2018, kept the same of 2017      
    NominalTESCorrection1Pr          = cms.double(-1.3), #DecayMode==0                                 
    NominalTESCorrection1PrPi0       = cms.double(-0.5), #DecayMode==1                                 
    NominalTESCorrection3Pr          = cms.double(-1.2), #DecayMode==10                                
-   NominalTESCorrection3PrPi0       = cms.double(-0.1), #DecayMode==11 -- Missing for 2018                               
+   NominalTESCorrection3PrPi0       = cms.double(-0.1), #DecayMode==11 -- Missing for 2018, kept the same of 2017                               
 
    ApplyTESCentralCorr = cms.bool(APPLYTESCORRECTION),
    # ApplyTESUpDown = cms.bool(True if IsMC else False), # no shift computation when data

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -49,7 +49,7 @@ from Configuration.AlCa.autoCond import autoCond
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")    
 #process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 if IsMC:
-    process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v12'  # 2018 MC
+    process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v18'  # 2018 MC
 else :
     process.GlobalTag.globaltag = '102X_dataRun2_Sep2018Rereco_v1'  # 2018 Data
 print process.GlobalTag.globaltag
@@ -137,7 +137,7 @@ process.goodPrimaryVertices = cms.EDFilter("VertexSelector",
 )
 
 #2017 ECAL bad calibration filter to be rerun, fix from https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#How_to_run_ecal_BadCalibReducedM
-# FIXME: to be updated to 2018
+# FIXME: to be updated to 2018 --> No difference w.r.t to ttH branch, maybe already updated?
 process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
 
 baddetEcallist = cms.vuint32(
@@ -255,7 +255,7 @@ process.cleanSoftElectrons = cms.EDProducer("PATElectronCleaner",
 ## Taus
 ##
 
-# FIXME:  to be updated for 2018
+# Davide first update for 2018 May 2019
 from LLRHiggsTauTau.NtupleProducer.runTauIdMVA import *
 na = TauIDEmbedder(process, cms, # pass tour process object
     debug=True,
@@ -314,21 +314,16 @@ process.softTaus = cms.EDProducer("TauFiller",
    vtxCollection = cms.InputTag("goodPrimaryVertices"),
    cut = cms.string(TAUCUT),
    discriminator = cms.string(TAUDISCRIMINATOR),
-   # --> Correct values for 2017 data - Uncertainty 3.0%
-   # NominalTESUncertainty      = cms.double(3.0) , # in percent, up/down uncertainty of TES
-   # NominalTESCorrection1Pr    = cms.double(-3.0), #DecayMode==0
-   # NominalTESCorrection1PrPi0 = cms.double(-2.0), #DecayMode==1
-   # NominalTESCorrection3Pr    = cms.double(-1.0), #DecayMode==10
 
-   # --> Correct values for 2017 data - Chiara update Jan2019
-   NominalTESUncertainty1Pr         = cms.double(0.8) , # in percent, up/down uncertainty of TES      
-   NominalTESUncertainty1PrPi0      = cms.double(0.8) , # in percent, up/down uncertainty of TES      
+   # --> Correct values for 2018 data - Davide update May2019
+   NominalTESUncertainty1Pr         = cms.double(1.1) , # in percent, up/down uncertainty of TES      
+   NominalTESUncertainty1PrPi0      = cms.double(0.9) , # in percent, up/down uncertainty of TES      
    NominalTESUncertainty3Pr         = cms.double(0.9) , # in percent, up/down uncertainty of TES      
-   NominalTESUncertainty3PrPi0      = cms.double(1.0) , # in percent, up/down uncertainty of TES      
-   NominalTESCorrection1Pr          = cms.double(0.7), #DecayMode==0                                 
-   NominalTESCorrection1PrPi0       = cms.double(-0.2), #DecayMode==1                                 
-   NominalTESCorrection3Pr          = cms.double(0.1), #DecayMode==10                                
-   NominalTESCorrection3PrPi0       = cms.double(-0.1), #DecayMode==11                                
+   NominalTESUncertainty3PrPi0      = cms.double(1.0) , # in percent, up/down uncertainty of TES -- Missing for 2018      
+   NominalTESCorrection1Pr          = cms.double(-1.3), #DecayMode==0                                 
+   NominalTESCorrection1PrPi0       = cms.double(-0.5), #DecayMode==1                                 
+   NominalTESCorrection3Pr          = cms.double(-1.2), #DecayMode==10                                
+   NominalTESCorrection3PrPi0       = cms.double(-0.1), #DecayMode==11 -- Missing for 2018                               
 
    ApplyTESCentralCorr = cms.bool(APPLYTESCORRECTION),
    # ApplyTESUpDown = cms.bool(True if IsMC else False), # no shift computation when data

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -150,7 +150,7 @@ baddetEcallist = cms.vuint32(
      872437185,872422564,872421566,872421695,
      872421955,872421567,872437184,872421951,
      872421694,872437056,872437057,872437313])
-
+     
 
 process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
     "EcalBadCalibFilter",
@@ -198,20 +198,10 @@ process.muons =  cms.Sequence(process.bareSoftMuons+ process.softMuons)
 # Load tools and function definitions
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
-process.load("RecoEgamma.ElectronIdentification.ElectronMVAValueMapProducer_cfi")
-#process.load("RecoEgamma.ElectronIdentification.ElectronRegressionValueMapProducer_cfi")
-
 #**********************
 dataFormat = DataFormat.MiniAOD
 switchOnVIDElectronIdProducer(process, dataFormat)
 #**********************
-
-process.load("RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cfi")
-# overwrite a default parameter: for miniAOD, the collection name is a slimmed one
-process.egmGsfElectronIDs.physicsObjectSrc = cms.InputTag('slimmedElectrons')
-
-from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
-process.egmGsfElectronIDSequence = cms.Sequence(process.egmGsfElectronIDs)
 
 process.softElectrons = cms.EDProducer("EleFiller",
    src    = cms.InputTag("slimmedElectrons"),
@@ -532,8 +522,8 @@ from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMet
 
 runMetCorAndUncFromMiniAOD (
         process,
-        isData = True, # false for MC
-        fixEE2017 = True,
+        isData = (not IsMC),
+        fixEE2017 = False, 
         fixEE2017Params = {'userawPt': True, 'ptThreshold':50.0, 'minEtaThreshold':2.65, 'maxEtaThreshold': 3.139} ,
         postfix = "ModifiedMET"
 )

--- a/NtupleProducer/python/triggers_102X.py
+++ b/NtupleProducer/python/triggers_102X.py
@@ -77,7 +77,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(11),
         leg2 = cms.int32(999)
         ),
-### === mu tauh triggers -- CHECK first muon filter, I think it's wrong on the TauTrigger twiki
+### === mu tauh triggers -- CHECK first muon filter, I think it's wrong on the TauTrigger twiki -- TauTrigger twiki has been corrected on 2019-04-29
     cms.PSet (
         HLT = cms.string("HLT_IsoMu20_eta2p1_LooseChargedIsoPFTauHPS27_eta2p1_CrossL1_v"),
         path1 = cms.vstring ("hltL3crIsoBigORMu18erTauXXer2p1L1f0L2f10QL3f20QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded"),
@@ -569,7 +569,148 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
-    )
+	
+## Monitoring triggers for 2018 data taking -- Filters should be checked
+    
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTauHPS35_Trk1_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltHpsSelectedPFTau35TrackPt1MediumChargedIsolationL1HLTMatchedReg","hltHpsOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTauHPS35_Trk1_TightID_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltHpsSelectedPFTau35TrackPt1MediumChargedIsolationAndTightOOSCPhotonsL1HLTMatchedReg","hltHpsOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTauHPS35_Trk1_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu24TightChargedIsoPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltHpsSelectedPFTau35TrackPt1TightChargedIsolationL1HLTMatchedReg","hltHpsOverlapFilterIsoMu24TightChargedIsoPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTauHPS35_Trk1_TightID_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu24TightChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltHpsSelectedPFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsL1HLTMatchedReg","hltHpsOverlapFilterIsoMu24TightChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_LooseChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu27LooseChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltHpsPFTau20TrackLooseChargedIsoAgainstMuon","hltHpsOverlapFilterIsoMu27LooseChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_MediumChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu27MediumChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltHpsPFTau20TrackMediumChargedIsoAgainstMuon","hltHpsOverlapFilterIsoMu27MediumChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_TightChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu27TightChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltHpsPFTau20TrackTightChargedIsoAgainstMuon","hltHpsOverlapFilterIsoMu27TightChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22erIsoTau40erL1f0L2f10QL3f24QL3trkIsoFiltered0p07",""),
+        path2 = cms.vstring ("hltSelectedPFTau50MediumChargedIsolationL1HLTMatchedMu22IsoTau40",""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+	
+    ## Duplicate trigger names without "HPS" - See https://twiki.cern.ch/twiki/bin/view/CMS/TauTrigger#Trigger_table_for_2018 - HPS deployed in Menu v2.2
+    
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau35_Trk1_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltSelectedPFTau35TrackPt1MediumChargedIsolationL1HLTMatchedReg","hltOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg","hltOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTau35_Trk1_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24TightChargedIsoPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltSelectedPFTau35TrackPt1TightChargedIsolationL1HLTMatchedReg","hltOverlapFilterIsoMu24TightChargedIsoPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24TightChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltSelectedPFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsL1HLTMatchedReg","hltOverlapFilterIsoMu24TightChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_LooseChargedIsoPFTau20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu27LooseChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseChargedIsoAgainstMuon","hltOverlapFilterIsoMu27LooseChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_MediumChargedIsoPFTau20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu27MediumChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackMediumChargedIsoAgainstMuon","hltOverlapFilterIsoMu27MediumChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_TightChargedIsoPFTau20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu27TightChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackTightChargedIsoAgainstMuon","hltOverlapFilterIsoMu27TightChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        )    
+     )
 
 #now I create the trigger list for HLTconfig
 for i in range(len(HLTLIST)):

--- a/NtupleProducer/python/triggers_102X.py
+++ b/NtupleProducer/python/triggers_102X.py
@@ -569,7 +569,148 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(15),
         leg2 = cms.int32(15)
         ),
-    )
+	
+## Monitoring triggers for 2018 data taking -- Filters should be checked
+    
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTauHPS35_Trk1_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltHpsSelectedPFTau35TrackPt1MediumChargedIsolationL1HLTMatchedReg","hltHpsOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTauHPS35_Trk1_TightID_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltHpsSelectedPFTau35TrackPt1MediumChargedIsolationAndTightOOSCPhotonsL1HLTMatchedReg","hltHpsOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTauHPS35_Trk1_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu24TightChargedIsoPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltHpsSelectedPFTau35TrackPt1TightChargedIsolationL1HLTMatchedReg","hltHpsOverlapFilterIsoMu24TightChargedIsoPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTauHPS35_Trk1_TightID_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu24TightChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltHpsSelectedPFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsL1HLTMatchedReg","hltHpsOverlapFilterIsoMu24TightChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_LooseChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu27LooseChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltHpsPFTau20TrackLooseChargedIsoAgainstMuon","hltHpsOverlapFilterIsoMu27LooseChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_MediumChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu27MediumChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltHpsPFTau20TrackMediumChargedIsoAgainstMuon","hltHpsOverlapFilterIsoMu27MediumChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_TightChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltHpsOverlapFilterIsoMu27TightChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltHpsPFTau20TrackTightChargedIsoAgainstMuon","hltHpsOverlapFilterIsoMu27TightChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22erIsoTau40erL1f0L2f10QL3f24QL3trkIsoFiltered0p07",""),
+        path2 = cms.vstring ("hltSelectedPFTau50MediumChargedIsolationL1HLTMatchedMu22IsoTau40",""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+	
+    ## Duplicate trigger names without "HPS" - See https://twiki.cern.ch/twiki/bin/view/CMS/TauTrigger#Trigger_table_for_2018 - HPS deployed in Menu v2.2
+    
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau35_Trk1_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltSelectedPFTau35TrackPt1MediumChargedIsolationL1HLTMatchedReg","hltOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg","hltOverlapFilterIsoMu24MediumChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTau35_Trk1_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24TightChargedIsoPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltSelectedPFTau35TrackPt1TightChargedIsolationL1HLTMatchedReg","hltOverlapFilterIsoMu24TightChargedIsoPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu24_eta2p1_TightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_CrossL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sBigOrMuXXerIsoTauYYerL1f0L2f10QL3f24QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu24TightChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path2 = cms.vstring ("hltSelectedPFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsL1HLTMatchedReg","hltOverlapFilterIsoMu24TightChargedIsoAndTightOOSCPhotonsPFTau35MonitoringReg"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_LooseChargedIsoPFTau20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu27LooseChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackLooseChargedIsoAgainstMuon","hltOverlapFilterIsoMu27LooseChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_MediumChargedIsoPFTau20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu27MediumChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackMediumChargedIsoAgainstMuon","hltOverlapFilterIsoMu27MediumChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_IsoMu27_TightChargedIsoPFTau20_Trk1_eta2p1_SingleL1_v"), 
+        path1 = cms.vstring ("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07","hltOverlapFilterIsoMu27TightChargedIsoPFTau20"),
+        path2 = cms.vstring ("hltPFTau20TrackTightChargedIsoAgainstMuon","hltOverlapFilterIsoMu27TightChargedIsoPFTau20"),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(13),
+        leg2 = cms.int32(15)
+        )    
+     )
 
 #now I create the trigger list for HLTconfig
 for i in range(len(HLTLIST)):

--- a/NtupleProducer/src/LeptonIsoHelper.cc
+++ b/NtupleProducer/src/LeptonIsoHelper.cc
@@ -359,6 +359,8 @@ std::pair<float,float> LeptonIsoHelper::miniRelIso_ChargedNeutral(const reco::Ca
   float eta = cand->eta();
 
   if(cand->isElectron()){
+  
+  // Values from 2017 analysis. To be updated
         
     if(      fabs(eta) >= 0     && fabs(eta) < 1.0 )    EffArea = 0.1566;
     else if( fabs(eta) >= 1.0   && fabs(eta) < 1.479 )  EffArea = 0.1626;
@@ -371,6 +373,8 @@ std::pair<float,float> LeptonIsoHelper::miniRelIso_ChargedNeutral(const reco::Ca
   }
 
   else if(cand->isMuon()){
+  
+  // Values from 2017 analysis. To be updated
 
     if(      fabs(eta) >= 0   && fabs(eta) < 0.8 )   EffArea = 0.0566;
     else if( fabs(eta) >= 0.8 && fabs(eta) < 1.3 )   EffArea = 0.0562;

--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ cd EGamma/EGammaAnalysisTools
 git checkout c0db796 -- interface/ElectronEffectiveArea.h
 cd -
 
+# FSR corrections
+git clone -n https://github.com/VBF-HZZ/UFHZZAnalysisRun2
+cd UFHZZAnalysisRun2
+git checkout origin/102X FSRPhotons
+cd -
+
 # bad MET filter fix
 git cms-addpkg RecoMET/METFilters
 


### PR DESCRIPTION
Updates for 2018 data sample analysis:
- added monitoring triggers (https://twiki.cern.ch/twiki/bin/view/CMS/TauTrigger)
- Added deepFlavour branches
- Updated instructions for FSR modules
- Added new TES corrections and uncertainties (https://twiki.cern.ch/twiki/bin/view/CMS/TauIDRecommendation13TeV)
- Removed reprocessing of electrons ID (default in 102X)