### PR TITLE
Tau ID for 2018 sample

### DIFF
--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -529,7 +529,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   //std::vector<int> _daughters_iseleCUT; //CUT ID for ele (0=veto,1=loose,2=medium,3=tight) //FRA January2019
   std::vector<Int_t> _decayType;//for taus only
   std::vector<Long64_t> _daughters_tauID; //bitwise. check h_tauID for histogram list 
-  static const int ntauIds = 41;
+  static const int ntauIds = 61;
   TString tauIDStrings[ntauIds] = {
    "byLooseCombinedIsolationDeltaBetaCorr3Hits",
    "byMediumCombinedIsolationDeltaBetaCorr3Hits",
@@ -572,7 +572,27 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
    "byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
    "byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
    "byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
-  };
+   "byVVVLooseDeepTau2017v2VSjet",
+   "byVVLooseDeepTau2017v2VSjet", 
+   "byVLooseDeepTau2017v2VSjet",  
+   "byLooseDeepTau2017v2VSjet",   
+   "byMediumDeepTau2017v2VSjet",  
+   "byTightDeepTau2017v2VSjet",   
+   "byVTightDeepTau2017v2VSjet",  
+   "byVVTightDeepTau2017v2VSjet", 
+   "byVVVLooseDeepTau2017v2VSe",  
+   "byVVLooseDeepTau2017v2VSe", 
+   "byVLooseDeepTau2017v2VSe",   
+   "byLooseDeepTau2017v2VSe",	
+   "byMediumDeepTau2017v2VSe",   
+   "byTightDeepTau2017v2VSe",	
+   "byVTightDeepTau2017v2VSe",   
+   "byVVTightDeepTau2017v2VSe",   
+   "byVLoosmuDmumupTau2017v2VSmu", 
+   "byLoosmuDmumupTau2017v2VSmu", 
+   "byMmudiumDmumupTau2017v2VSmu", 
+   "byTightDmumupTau2017v2VSmu", 
+ };
   std::vector<Float_t> _daughters_IetaIeta;
   std::vector<Float_t> _daughters_full5x5_IetaIeta;
   std::vector<Float_t> _daughters_hOverE;
@@ -594,6 +614,9 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017; //FRA
   std::vector<Float_t> _daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017; //FRA
   std::vector<Float_t> _daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017; //FRA
+  std::vector<Float_t> _daughters_byDeepTau2017v2VSjetraw;
+  std::vector<Float_t> _daughters_byDeepTau2017v2VSeraw;
+  std::vector<Float_t> _daughters_byDeepTau2017v2VSmuraw;
   std::vector<Int_t> _daughters_byVVLooseIsolationMVArun2017v2DBoldDMwLT2017; //FRA
   std::vector<Float_t> _daughters_chargedIsoPtSum;
   std::vector<Float_t> _daughters_neutralIsoPtSum;
@@ -1013,6 +1036,9 @@ void HTauTauNtuplizer::Initialize(){
   _daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017.clear();      //FRA
   _daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017.clear();      //FRA
   _daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017.clear(); //FRA
+  _daughters_byDeepTau2017v2VSjetraw.clear();
+  _daughters_byDeepTau2017v2VSeraw.clear();
+  _daughters_byDeepTau2017v2VSmuraw.clear();
   _daughters_byVVLooseIsolationMVArun2017v2DBoldDMwLT2017.clear(); //FRA
   _daughters_footprintCorrection.clear();
   _daughters_neutralIsoPtSumWeight.clear();
@@ -1725,6 +1751,9 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017",&_daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017); //FRA
   myTree->Branch("daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017",&_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017); //FRA
   myTree->Branch("daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017",&_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017); //FRA
+  myTree->Branch("daughters_byDeepTau2017v2VSjetraw",&_daughters_byDeepTau2017v2VSjetraw);
+  myTree->Branch("daughters_byDeepTau2017v2VSeraw",&_daughters_byDeepTau2017v2VSeraw);
+  myTree->Branch("daughters_byDeepTau2017v2VSmuraw",&_daughters_byDeepTau2017v2VSmuraw);
   myTree->Branch("daughters_byVVLooseIsolationMVArun2017v2DBoldDMwLT2017", &_daughters_byVVLooseIsolationMVArun2017v2DBoldDMwLT2017); //FRA
   myTree->Branch("daughters_chargedIsoPtSum", &_daughters_chargedIsoPtSum);
   myTree->Branch("daughters_neutralIsoPtSum", &_daughters_neutralIsoPtSum);
@@ -3307,6 +3336,7 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     float leadChargedParticlePt=-1., trackRefPt=-1.;
     int typeOfMuon=0;
     float byIsolationMVArun2v1DBoldDMwLTraw=-1, byIsolationMVArun2017v2DBoldDMwLTraw2017=-1, byIsolationMVArun2017v1DBoldDMwLTraw2017=-1, byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017=-1; //FRA
+    float byDeepTau2017v2VSjetraw=-1, byDeepTau2017v2VSeraw=-1, byDeepTau2017v2VSmuraw=-1;
     int  byVVLooseIsolationMVArun2017v2DBoldDMwLT2017=-1; //FRA
     Long64_t tauIDflag = 0;
     float footprintCorrection, neutralIsoPtSumWeight, photonPtSumOutsideSignalCone;
@@ -3414,6 +3444,9 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
       byIsolationMVArun2017v2DBoldDMwLTraw2017=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2017v2DBoldDMwLTraw2017"); //FRA
       byIsolationMVArun2017v1DBoldDMwLTraw2017=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2017v1DBoldDMwLTraw2017"); //FRA
       byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017"); //FRA
+      byDeepTau2017v2VSjetraw=userdatahelpers::getUserFloat(cand,"byDeepTau2017v2VSjetraw");
+      byDeepTau2017v2VSeraw=userdatahelpers::getUserFloat(cand,"byDeepTau2017v2VSeraw");
+      byDeepTau2017v2VSmuraw=userdatahelpers::getUserFloat(cand,"byDeepTau2017v2VSmuraw");
       byVVLooseIsolationMVArun2017v2DBoldDMwLT2017= userdatahelpers::getUserInt (cand, "byVVLooseIsolationMVArun2017v2DBoldDMwLT2017"); //FRA
       chargedIsoPtSum = userdatahelpers::getUserFloat (cand, "chargedIsoPtSum");
       neutralIsoPtSum = userdatahelpers::getUserFloat (cand, "neutralIsoPtSum");
@@ -3489,6 +3522,9 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     _daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017.push_back(byIsolationMVArun2017v2DBoldDMwLTraw2017); //FRA
     _daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017.push_back(byIsolationMVArun2017v1DBoldDMwLTraw2017); //FRA
     _daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017.push_back(byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017); //FRA
+    _daughters_byDeepTau2017v2VSjetraw.push_back(byDeepTau2017v2VSjetraw);
+    _daughters_byDeepTau2017v2VSeraw.push_back(byDeepTau2017v2VSeraw);
+    _daughters_byDeepTau2017v2VSmuraw.push_back(byDeepTau2017v2VSmuraw);
     _daughters_byVVLooseIsolationMVArun2017v2DBoldDMwLT2017.push_back(byVVLooseIsolationMVArun2017v2DBoldDMwLT2017); //FRA
     _daughters_numChargedParticlesSignalCone.push_back(numChargedParticlesSignalCone);
     _daughters_numNeutralHadronsSignalCone.push_back(numNeutralHadronsSignalCone);

--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -141,6 +141,30 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
     "byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
     "byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
+    
+    "byVVVLooseDeepTau2017v2VSjet",
+    "byVVLooseDeepTau2017v2VSjet", 
+    "byVLooseDeepTau2017v2VSjet",  
+    "byLooseDeepTau2017v2VSjet",   
+    "byMediumDeepTau2017v2VSjet",  
+    "byTightDeepTau2017v2VSjet",   
+    "byVTightDeepTau2017v2VSjet",  
+    "byVVTightDeepTau2017v2VSjet", 
+    
+    "byVVVLooseDeepTau2017v2VSe",  
+    "byVVLooseDeepTau2017v2VSe", 
+    "byVLooseDeepTau2017v2VSe",   
+    "byLooseDeepTau2017v2VSe",   
+    "byMediumDeepTau2017v2VSe",   
+    "byTightDeepTau2017v2VSe",   
+    "byVTightDeepTau2017v2VSe",   
+    "byVVTightDeepTau2017v2VSe",   
+    
+    "byVLoosmuDmumupTau2017v2VSmu",
+    "byLoosmuDmumupTau2017v2VSmu", 
+    "byMmudiumDmumupTau2017v2VSmu",
+    "byTightDmumupTau2017v2VSmu", 
+
   };
 
   tauFloatDiscrims_ =
@@ -157,7 +181,10 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "byIsolationMVArun2017v1DBoldDMwLTraw2017",      //FRA syncApr2018
     "byIsolationMVArun2017v2DBoldDMwLTraw2017",      //FRA syncApr2018
     "byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017", //FRA syncApr2018
-  };
+    "byDeepTau2017v2VSjetraw",  
+    "byDeepTau2017v2VSeraw",  
+    "byDeepTau2017v2VSmuraw",
+   };
 
 
 }

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -248,17 +248,22 @@ process.cleanSoftElectrons = cms.EDProducer("PATElectronCleaner",
 ##
 
 # Davide first update for 2018 May 2019
-from LLRHiggsTauTau.NtupleProducer.runTauIdMVA import *
-na = TauIDEmbedder(process, cms, # pass tour process object
-    debug=True,
-    toKeep = ["2017v1", "2017v2", "dR0p32017v2"] # pick the one you need: ["2017v1", "2017v2", "newDM2017v2", "dR0p32017v2", "2016v1", "newDM2016v1"]
+import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
+
+updatedTauName = "slimmedTausNewID" #name of pat::Tau collection with new tau-Ids
+
+
+tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = True,
+                    updatedTauName = updatedTauName,
+                    toKeep = ["deepTau2017v2", "2017v1", "2017v2", "dR0p32017v2"] # pick the one you need: ["2017v1", "2017v2", "newDM2017v2", "dR0p32017v2", "2016v1", "newDM2016v1",
+		                                                                                           #"deepTau2017v1", "deepTau2017v2","DPFTau_2016_v0"] discriminators in this line are based on DNN
 )
-na.runTauID()
+
+tauIdEmbedder.runTauID()
 
 # old sequence starts here
 process.bareTaus = cms.EDFilter("PATTauRefSelector",
-   #src = cms.InputTag("slimmedTaus"),
-   src = cms.InputTag("NewTauIDsEmbedded"),
+   src = cms.InputTag("slimmedTausNewID"), 
    cut = cms.string(TAUCUT),
    )
 
@@ -325,8 +330,7 @@ process.softTaus = cms.EDProducer("TauFiller",
    )
 
 
-process.taus=cms.Sequence(process.rerunMvaIsolationSequence + process.NewTauIDsEmbedded + process.bareTaus + process.softTaus)
-
+process.taus=cms.Sequence(process.rerunMvaIsolationSequence + process.slimmedTausNewID + process.bareTaus + process.softTaus)
 
 ### ----------------------------------------------------------------------
 ### gen info, only from MC
@@ -408,6 +412,7 @@ process.jets = cms.EDFilter("PATJetRefSelector",
 ##
 ## QG tagging for jets
 ##
+
 if COMPUTEQGVAR:
     qgDatabaseVersion = 'v2b' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 
@@ -430,10 +435,9 @@ if COMPUTEQGVAR:
     process.QGTagger.jetsLabel        = cms.string('QGL_AK4PFchs')        # Other options: see https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
     process.jetSequence = cms.Sequence(process.jets * process.QGTagger)
 
+
 else:
     process.jetSequence = cms.Sequence(process.jets)
-
-
 
 
 # il primo legge la collezione dei leptoni e stampa quali sono

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -414,27 +414,27 @@ process.jets = cms.EDFilter("PATJetRefSelector",
 ##
 
 if COMPUTEQGVAR:
-    qgDatabaseVersion = 'v2b' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 
-    from CondCore.CondDB.CondDB_cfi import *
-    QGPoolDBESSource = cms.ESSource("PoolDBESSource",
-                                    toGet = cms.VPSet(),
-                                    connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),
+    from CondCore.CondDB.CondDB_cfi import CondDB
+     
+    process.QGPoolDBESSource = cms.ESSource("PoolDBESSource",
+      CondDB.clone(
+        connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+      ),
+      toGet = cms.VPSet(
+        cms.PSet(
+          record = cms.string('QGLikelihoodRcd'),
+          tag    = cms.string('QGLikelihoodObject_v1_AK4PFchs_2017'),
+          label  = cms.untracked.string('QGL_AK4PFchs'),
+        ),
+      ),
     )
-    
-    for type in ['AK4PFchs']:
-        QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
-                    record = cms.string('QGLikelihoodRcd'),
-                    tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
-                    label  = cms.untracked.string('QGL_'+type)
-                    )))
-
+    process.es_prefer_qg = cms.ESPrefer("PoolDBESSource", "QGPoolDBESSource")
 
     process.load('RecoJets.JetProducers.QGTagger_cfi')
     process.QGTagger.srcJets          = cms.InputTag("jets")    # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
     process.QGTagger.jetsLabel        = cms.string('QGL_AK4PFchs')        # Other options: see https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
     process.jetSequence = cms.Sequence(process.jets * process.QGTagger)
-
 
 else:
     process.jetSequence = cms.Sequence(process.jets)

--- a/README.md
+++ b/README.md
@@ -432,8 +432,12 @@ git cms-merge-topic cms-egamma:EgammaPostRecoTools_dev
 
 #Add DeepTau code from Tau POG repository (note "-u" option preventing checkout of unnecessary stuff)
 git cms-merge-topic -u cms-tau-pog:CMSSW_10_2_X_tau-pog_DeepTau2017v2
-#Add 2017v2 training file
-wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/DeepTau2017v2_alone/DeepTauId/deepTau_2017v2p6_e6.pb -P RecoTauTag/TrainingFiles/data/DeepTauId
+
+#Add 2017v2 training file by using "git clone" or wget
+# git clone -b DeepTau2017v2_alone https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles.git RecoTauTag/TrainingFiles/data
+wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/DeepTau2017v2/DeepTauId/deepTau_2017v2p6_e6_core.pb -P RecoTauTag/TrainingFiles/data/DeepTauId
+wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/DeepTau2017v2/DeepTauId/deepTau_2017v2p6_e6_inner.pb -P RecoTauTag/TrainingFiles/data/DeepTauId
+wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/DeepTau2017v2/DeepTauId/deepTau_2017v2p6_e6_outer.pb -P RecoTauTag/TrainingFiles/data/DeepTauId
 
 cd $CMSSW_BASE/src
 scram b -j 8

--- a/README.md
+++ b/README.md
@@ -378,8 +378,8 @@ scram b -j 8
 ### Instructions for 102X
 
 ```
-cmsrel CMSSW_10_2_5
-cd CMSSW_10_2_5/src
+cmsrel CMSSW_10_2_14
+cd CMSSW_10_2_14/src
 cmsenv
 
 # MVA EleID Fall 2018
@@ -420,6 +420,20 @@ git cms-merge-topic cms-met:METFixEE2017_949_v2_backport_to_102X
 # SVfit
 git clone https://github.com/SVfit/ClassicSVfit TauAnalysis/ClassicSVfit -b release_2018Mar20
 git clone https://github.com/svfit/SVfitTF TauAnalysis/SVfitTF
+
+# Egamma Energy corrections
+git cms-addpkg EgammaAnalysis/ElectronTools
+rm EgammaAnalysis/ElectronTools/data -rf
+git clone git@github.com:cms-egamma/EgammaAnalysis-ElectronTools.git EgammaAnalysis/ElectronTools/data
+cd EgammaAnalysis/ElectronTools/data
+git checkout ScalesSmearing2018_Dev
+cd -
+git cms-merge-topic cms-egamma:EgammaPostRecoTools_dev
+
+#Add DeepTau code from Tau POG repository (note "-u" option preventing checkout of unnecessary stuff)
+git cms-merge-topic -u cms-tau-pog:CMSSW_10_2_X_tau-pog_DeepTau2017v2
+#Add 2017v2 training file
+wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/DeepTau2017v2_alone/DeepTauId/deepTau_2017v2p6_e6.pb -P RecoTauTag/TrainingFiles/data/DeepTauId
 
 cd $CMSSW_BASE/src
 scram b -j 8


### PR DESCRIPTION
- Added instructions for DNN TauID and Egamma energy corrections to README (newer CMSSW version required for both) (https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePFTauID#Running_of_the_DeepTauIDs_ver_20 and https://twiki.cern.ch/twiki/bin/view/CMS/EgammaMiniAODV2)

- Added new branches for the TauID based on DNN to the ntuplizer
- Added DNN TauID discriminators to the TauFiller
- Added code to run the new TauID including the new DNN based discriminator to the producer 
(https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePFTauID#Running_of_the_DeepTauIDs_ver_20)