### PR TITLE
Spread ele->tauh ES to the rest of the framework

### DIFF
--- a/NtupleProducer/plugins/ClassicSVfitInterface.cc
+++ b/NtupleProducer/plugins/ClassicSVfitInterface.cc
@@ -86,6 +86,10 @@ class ClassicSVfitInterface : public edm::EDProducer {
   edm::EDGetTokenT<double> theMETdyUPTag;
   edm::EDGetTokenT<double> theMETdxDOWNTag;
   edm::EDGetTokenT<double> theMETdyDOWNTag;
+  edm::EDGetTokenT<double> theMETdxUPEESTag;
+  edm::EDGetTokenT<double> theMETdyUPEESTag;
+  edm::EDGetTokenT<double> theMETdxDOWNEESTag;
+  edm::EDGetTokenT<double> theMETdyDOWNEESTag;
   TFile* inputFile_visPtResolution_;
   
   // 6,7,8 are expected to be unused
@@ -114,7 +118,11 @@ theCovTag(consumes<math::Error<2>::type>(iConfig.getParameter<edm::InputTag>("sr
 theMETdxUPTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdxUP"))),
 theMETdyUPTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdyUP"))),
 theMETdxDOWNTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdxDOWN"))),
-theMETdyDOWNTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdyDOWN")))
+theMETdyDOWNTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdyDOWN"))),
+theMETdxUPEESTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdxUP_EES"))),
+theMETdyUPEESTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdyUP_EES"))),
+theMETdxDOWNEESTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdxDOWN_EES"))),
+theMETdyDOWNEESTag(consumes<double>(iConfig.getParameter<edm::InputTag>("METdyDOWN_EES")))
 {
   //theCandidateTag = iConfig.getParameter<InputTag>("srcPairs");
   _usePairMET = iConfig.getParameter<bool>("usePairMET");
@@ -164,17 +172,22 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
   TMatrixD covMET(2, 2);
   float significance = -999.;
 
-  double METx_UP   = 0.;
-  double METy_UP   = 0.;
-  double METx_DOWN = 0.;
-  double METy_DOWN = 0.;
+  double METx_UP_JES   = 0.;
+  double METy_UP_JES   = 0.;
+  double METx_DOWN_JES = 0.;
+  double METy_DOWN_JES = 0.;
 
   double METx_UP_TES = 0.;
   double METy_UP_TES = 0.;
   double METx_DOWN_TES = 0.;
   double METy_DOWN_TES = 0.;
 
-  iEvent.getByToken(theMETTag, METHandle);    
+  double METx_UP_EES = 0.;
+  double METy_UP_EES = 0.;
+  double METx_DOWN_EES = 0.;
+  double METy_DOWN_EES = 0.;
+
+  iEvent.getByToken(theMETTag, METHandle);
   // initialize MET once if not using PairMET
   if (!_usePairMET)
   {   
@@ -192,7 +205,11 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
      Handle<double> METyUPHandle;
      Handle<double> METxDOWNHandle;
      Handle<double> METyDOWNHandle;
-     
+     Handle<double> METxUPEESHandle;
+     Handle<double> METyUPEESHandle;
+     Handle<double> METxDOWNEESHandle;
+     Handle<double> METyDOWNEESHandle;
+
      iEvent.getByToken (theSigTag, significanceHandle);
      iEvent.getByToken (theCovTag, covHandle);
      
@@ -200,6 +217,10 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
      iEvent.getByToken (theMETdyUPTag, METyUPHandle);
      iEvent.getByToken (theMETdxDOWNTag, METxDOWNHandle);
      iEvent.getByToken (theMETdyDOWNTag, METyDOWNHandle);
+     iEvent.getByToken (theMETdxUPEESTag, METxUPEESHandle);
+     iEvent.getByToken (theMETdyUPEESTag, METyUPEESHandle);
+     iEvent.getByToken (theMETdxDOWNEESTag, METxDOWNEESHandle);
+     iEvent.getByToken (theMETdyDOWNEESTag, METyDOWNEESHandle);
 
      covMET[0][0] = (*covHandle)(0,0);
      covMET[1][0] = (*covHandle)(1,0);
@@ -212,6 +233,10 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
      METy_UP_TES   = *METyUPHandle;
      METx_DOWN_TES = *METxDOWNHandle;
      METy_DOWN_TES = *METyDOWNHandle;
+     METx_UP_EES   = *METxUPEESHandle;
+     METy_UP_EES   = *METyUPEESHandle;
+     METx_DOWN_EES = *METxDOWNEESHandle;
+     METy_DOWN_EES = *METyDOWNEESHandle;
 
      // protection against singular matrices
      if (covMET[0][0] == 0 && covMET[1][0] == 0 && covMET[0][1] == 0 && covMET[1][1] == 0)
@@ -219,12 +244,12 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
                                                     << "   --> SVfit algorithm will probably crash...";
 
      // now get the MET shifted UP/DOWN by the JES
-     LorentzVector patMET_UP   = patMET.shiftedP4(METUncertainty::JetEnUp);
-     METx_UP = patMET_UP.px();
-     METy_UP = patMET_UP.py();
-     LorentzVector patMET_DOWN = patMET.shiftedP4(METUncertainty::JetEnDown);
-     METx_DOWN = patMET_DOWN.px();
-     METy_DOWN = patMET_DOWN.py();
+     LorentzVector patMET_UP_JES   = patMET.shiftedP4(METUncertainty::JetEnUp);
+     METx_UP_JES = patMET_UP_JES.px();
+     METy_UP_JES = patMET_UP_JES.py();
+     LorentzVector patMET_DOWN_JES = patMET.shiftedP4(METUncertainty::JetEnDown);
+     METx_DOWN_JES = patMET_DOWN_JES.px();
+     METy_DOWN_JES = patMET_DOWN_JES.py();
 
      //cout << " -------- CLASSIC SVIFT MET ---------" << endl;
      //cout << "MET       : " << patMET.px() << " / " << patMET.py() << endl;
@@ -252,10 +277,14 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
     classic_svFit::MeasuredTauLepton::kDecayType l2Type = GetDecayTypeFlag (l2->pdgId());
     double mass1 = GetMass (l1Type, l1->mass());
     double mass2 = GetMass (l2Type, l2->mass());
-    double mass1_UP   = -1.;
-    double mass1_DOWN = -1.;
-    double mass2_UP   = -1.;
-    double mass2_DOWN = -1.;
+    double mass1_tauUP   = -1.;
+    double mass1_tauDOWN = -1.;
+    double mass2_tauUP   = -1.;
+    double mass2_tauDOWN = -1.;
+    double mass1_eleUP   = -1.;
+    double mass1_eleDOWN = -1.;
+    double mass2_eleUP   = -1.;
+    double mass2_eleDOWN = -1.;
    
     int decay1 = -1;
     int decay2 = -1;
@@ -293,12 +322,12 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
       }
 
      // now get the MET shifted UP/DOWN by the JES
-     LorentzVector patMET_UP   = patMET->shiftedP4(METUncertainty::JetEnUp);
-     METx_UP = patMET_UP.px();
-     METy_UP = patMET_UP.py();
-     LorentzVector patMET_DOWN = patMET->shiftedP4(METUncertainty::JetEnDown);
-     METx_DOWN = patMET_DOWN.px();
-     METy_DOWN = patMET_DOWN.py();
+     LorentzVector patMET_UP_JES   = patMET->shiftedP4(METUncertainty::JetEnUp);
+     METx_UP_JES = patMET_UP_JES.px();
+     METy_UP_JES = patMET_UP_JES.py();
+     LorentzVector patMET_DOWN_JES = patMET->shiftedP4(METUncertainty::JetEnDown);
+     METx_DOWN_JES = patMET_DOWN_JES.px();
+     METy_DOWN_JES = patMET_DOWN_JES.py();
 
      // TES shift of MET
      Handle<double> METxUPHandle;
@@ -315,64 +344,129 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
      METy_UP_TES   = *METyUPHandle;
      METx_DOWN_TES = *METxDOWNHandle;
      METy_DOWN_TES = *METyDOWNHandle;
-    } 
+
+     // EES shift of MET (E->tau ES)
+     Handle<double> METxUPEESHandle;
+     Handle<double> METyUPEESHandle;
+     Handle<double> METxDOWNEESHandle;
+     Handle<double> METyDOWNEESHandle;
+
+     iEvent.getByToken (theMETdxUPEESTag, METxUPEESHandle);
+     iEvent.getByToken (theMETdyUPEESTag, METyUPEESHandle);
+     iEvent.getByToken (theMETdxDOWNEESTag, METxDOWNEESHandle);
+     iEvent.getByToken (theMETdyDOWNEESTag, METyDOWNEESHandle);
+
+     METx_UP_EES   = *METxUPEESHandle;
+     METy_UP_EES   = *METyUPEESHandle;
+     METx_DOWN_EES = *METxDOWNEESHandle;
+     METy_DOWN_EES = *METyDOWNEESHandle;
+    }
 
     // prepare tau nominal, up, down candidates            
     std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons;
     std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsTauUp;
     std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsTauDown;
+    std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsEleUp;
+    std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsEleDown;
 
     // init shifted version to nominal
-    TLorentzVector l1_UP (l1->px(), l1->py(), l1->pz(), l1->energy());
-    TLorentzVector l1_DOWN = l1_UP;
-    TLorentzVector l2_UP (l2->px(), l2->py(), l2->pz(), l2->energy());
-    TLorentzVector l2_DOWN = l2_UP;
+    TLorentzVector l1_tauUP (l1->px(), l1->py(), l1->pz(), l1->energy());
+    TLorentzVector l1_tauDOWN = l1_tauUP;
+    TLorentzVector l2_tauUP (l2->px(), l2->py(), l2->pz(), l2->energy());
+    TLorentzVector l2_tauDOWN = l2_tauUP;
+    TLorentzVector l1_eleUP (l1->px(), l1->py(), l1->pz(), l1->energy());
+    TLorentzVector l1_eleDOWN = l1_eleUP;
+    TLorentzVector l2_eleUP (l2->px(), l2->py(), l2->pz(), l2->energy());
+    TLorentzVector l2_eleDOWN = l2_eleUP;
 
-    bool l1shifted = false;
-    bool l2shifted = false;
-    if (userdatahelpers::hasUserInt(l1,"TauUpExists"))
-      l1shifted = (userdatahelpers::getUserInt(l1,"TauUpExists") == 1 ? true : false);
-    if (userdatahelpers::hasUserInt(l2,"TauUpExists"))
-      l2shifted = (userdatahelpers::getUserInt(l2,"TauUpExists") == 1 ? true : false);
+    bool l1shifted_tau = false;
+    bool l2shifted_tau = false;
+    bool l1shifted_ele = false;
+    bool l2shifted_ele = false;
 
-    if (l1shifted)
+    if (userdatahelpers::hasUserInt(l1,"isTESShifted")) l1shifted_tau = (userdatahelpers::getUserInt(l1,"isTESShifted") == 1 ? true : false);
+    if (userdatahelpers::hasUserInt(l2,"isTESShifted")) l2shifted_tau = (userdatahelpers::getUserInt(l2,"isTESShifted") == 1 ? true : false);
+    if (userdatahelpers::hasUserInt(l1,"isEESShifted")) l1shifted_ele = (userdatahelpers::getUserInt(l1,"isEESShifted") == 1 ? true : false);
+    if (userdatahelpers::hasUserInt(l2,"isEESShifted")) l2shifted_ele = (userdatahelpers::getUserInt(l2,"isEESShifted") == 1 ? true : false);
+
+    if (l1shifted_tau)
     {
       float pxUp = userdatahelpers::getUserFloat(l1,"px_TauUp");
       float pyUp = userdatahelpers::getUserFloat(l1,"py_TauUp");
       float pzUp = userdatahelpers::getUserFloat(l1,"pz_TauUp");
       float eUp  = userdatahelpers::getUserFloat(l1,"e_TauUp");
       float mUp  = userdatahelpers::getUserFloat(l1,"m_TauUp");
-      l1_UP.SetPxPyPzE (pxUp, pyUp, pzUp, eUp);
+      l1_tauUP.SetPxPyPzE (pxUp, pyUp, pzUp, eUp);
 
       float pxDown = userdatahelpers::getUserFloat(l1,"px_TauDown");
       float pyDown = userdatahelpers::getUserFloat(l1,"py_TauDown");
       float pzDown = userdatahelpers::getUserFloat(l1,"pz_TauDown");
       float eDown  = userdatahelpers::getUserFloat(l1,"e_TauDown");
       float mDown  = userdatahelpers::getUserFloat(l1,"m_TauDown");
-      l1_DOWN.SetPxPyPzE (pxDown, pyDown, pzDown, eDown);
+      l1_tauDOWN.SetPxPyPzE (pxDown, pyDown, pzDown, eDown);
 
-      mass1_UP   = GetMass (l1Type, mUp);
-      mass1_DOWN = GetMass (l1Type, mDown);
+      mass1_tauUP   = GetMass (l1Type, mUp);
+      mass1_tauDOWN = GetMass (l1Type, mDown);
     }
 
-    if (l2shifted)
+    if (l2shifted_tau)
     {
       float pxUp = userdatahelpers::getUserFloat(l2,"px_TauUp");
       float pyUp = userdatahelpers::getUserFloat(l2,"py_TauUp");
       float pzUp = userdatahelpers::getUserFloat(l2,"pz_TauUp");
       float eUp  = userdatahelpers::getUserFloat(l2,"e_TauUp");
       float mUp  = userdatahelpers::getUserFloat(l2,"m_TauUp");
-      l2_UP.SetPxPyPzE (pxUp, pyUp, pzUp, eUp);
+      l2_tauUP.SetPxPyPzE (pxUp, pyUp, pzUp, eUp);
 
       float pxDown = userdatahelpers::getUserFloat(l2,"px_TauDown");
       float pyDown = userdatahelpers::getUserFloat(l2,"py_TauDown");
       float pzDown = userdatahelpers::getUserFloat(l2,"pz_TauDown");
       float eDown  = userdatahelpers::getUserFloat(l2,"e_TauDown");
       float mDown  = userdatahelpers::getUserFloat(l2,"m_TauDown");
-      l2_DOWN.SetPxPyPzE (pxDown, pyDown, pzDown, eDown);
+      l2_tauDOWN.SetPxPyPzE (pxDown, pyDown, pzDown, eDown);
 
-      mass2_UP   = GetMass (l2Type, mUp);
-      mass2_DOWN = GetMass (l2Type, mDown);
+      mass2_tauUP   = GetMass (l2Type, mUp);
+      mass2_tauDOWN = GetMass (l2Type, mDown);
+    }
+
+    if (l1shifted_ele)
+    {
+      float pxUp = userdatahelpers::getUserFloat(l1,"px_EleUp");
+      float pyUp = userdatahelpers::getUserFloat(l1,"py_EleUp");
+      float pzUp = userdatahelpers::getUserFloat(l1,"pz_EleUp");
+      float eUp  = userdatahelpers::getUserFloat(l1,"e_EleUp");
+      float mUp  = userdatahelpers::getUserFloat(l1,"m_EleUp");
+      l1_eleUP.SetPxPyPzE (pxUp, pyUp, pzUp, eUp);
+
+      float pxDown = userdatahelpers::getUserFloat(l1,"px_EleDown");
+      float pyDown = userdatahelpers::getUserFloat(l1,"py_EleDown");
+      float pzDown = userdatahelpers::getUserFloat(l1,"pz_EleDown");
+      float eDown  = userdatahelpers::getUserFloat(l1,"e_EleDown");
+      float mDown  = userdatahelpers::getUserFloat(l1,"m_EleDown");
+      l1_eleDOWN.SetPxPyPzE (pxDown, pyDown, pzDown, eDown);
+
+      mass1_eleUP   = GetMass (l1Type, mUp);
+      mass1_eleDOWN = GetMass (l1Type, mDown);
+    }
+
+    if (l2shifted_ele)
+    {
+      float pxUp = userdatahelpers::getUserFloat(l2,"px_EleUp");
+      float pyUp = userdatahelpers::getUserFloat(l2,"py_EleUp");
+      float pzUp = userdatahelpers::getUserFloat(l2,"pz_EleUp");
+      float eUp  = userdatahelpers::getUserFloat(l2,"e_EleUp");
+      float mUp  = userdatahelpers::getUserFloat(l2,"m_EleUp");
+      l2_eleUP.SetPxPyPzE (pxUp, pyUp, pzUp, eUp);
+
+      float pxDown = userdatahelpers::getUserFloat(l2,"px_EleDown");
+      float pyDown = userdatahelpers::getUserFloat(l2,"py_EleDown");
+      float pzDown = userdatahelpers::getUserFloat(l2,"pz_EleDown");
+      float eDown  = userdatahelpers::getUserFloat(l2,"e_EleDown");
+      float mDown  = userdatahelpers::getUserFloat(l2,"m_EleDown");
+      l2_eleDOWN.SetPxPyPzE (pxDown, pyDown, pzDown, eDown);
+
+      mass2_eleUP   = GetMass (l2Type, mUp);
+      mass2_eleDOWN = GetMass (l2Type, mDown);
     }
 
     // set lepton vector, ordered for SVfit
@@ -381,11 +475,17 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
       measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2->pt(), l2->eta(), l2->phi(), mass2, decay2 ));
       measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1->pt(), l1->eta(), l1->phi(), mass1, decay1 ));
 
-      measuredTauLeptonsTauUp.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_UP.Pt(), l2_UP.Eta(), l2_UP.Phi(), mass2_UP, decay2 ));
-      measuredTauLeptonsTauUp.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_UP.Pt(), l1_UP.Eta(), l1_UP.Phi(), mass1_UP, decay1 ));
+      measuredTauLeptonsTauUp.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_tauUP.Pt(), l2_tauUP.Eta(), l2_tauUP.Phi(), mass2_tauUP, decay2 ));
+      measuredTauLeptonsTauUp.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_tauUP.Pt(), l1_tauUP.Eta(), l1_tauUP.Phi(), mass1_tauUP, decay1 ));
 
-      measuredTauLeptonsTauDown.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_DOWN.Pt(), l2_DOWN.Eta(), l2_DOWN.Phi(), mass2_DOWN, decay2 ));
-      measuredTauLeptonsTauDown.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_DOWN.Pt(), l1_DOWN.Eta(), l1_DOWN.Phi(), mass1_DOWN, decay1 ));
+      measuredTauLeptonsTauDown.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_tauDOWN.Pt(), l2_tauDOWN.Eta(), l2_tauDOWN.Phi(), mass2_tauDOWN, decay2 ));
+      measuredTauLeptonsTauDown.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_tauDOWN.Pt(), l1_tauDOWN.Eta(), l1_tauDOWN.Phi(), mass1_tauDOWN, decay1 ));
+
+      measuredTauLeptonsEleUp.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_eleUP.Pt(), l2_eleUP.Eta(), l2_eleUP.Phi(), mass2_eleUP, decay2 ));
+      measuredTauLeptonsEleUp.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_eleUP.Pt(), l1_eleUP.Eta(), l1_eleUP.Phi(), mass1_eleUP, decay1 ));
+
+      measuredTauLeptonsEleDown.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_eleDOWN.Pt(), l2_eleDOWN.Eta(), l2_eleDOWN.Phi(), mass2_eleDOWN, decay2 ));
+      measuredTauLeptonsEleDown.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_eleDOWN.Pt(), l1_eleDOWN.Eta(), l1_eleDOWN.Phi(), mass1_eleDOWN, decay1 ));
     }
 
     else
@@ -393,11 +493,17 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
       measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1->pt(), l1->eta(), l1->phi(), mass1, decay1 ));
       measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2->pt(), l2->eta(), l2->phi(), mass2, decay2 ));
 
-      measuredTauLeptonsTauUp.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_UP.Pt(), l1_UP.Eta(), l1_UP.Phi(), mass1_UP, decay1 ));
-      measuredTauLeptonsTauUp.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_UP.Pt(), l2_UP.Eta(), l2_UP.Phi(), mass2_UP, decay2 ));
+      measuredTauLeptonsTauUp.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_tauUP.Pt(), l1_tauUP.Eta(), l1_tauUP.Phi(), mass1_tauUP, decay1 ));
+      measuredTauLeptonsTauUp.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_tauUP.Pt(), l2_tauUP.Eta(), l2_tauUP.Phi(), mass2_tauUP, decay2 ));
 
-      measuredTauLeptonsTauDown.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_DOWN.Pt(), l1_DOWN.Eta(), l1_DOWN.Phi(), mass1_DOWN, decay1 ));
-      measuredTauLeptonsTauDown.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_DOWN.Pt(), l2_DOWN.Eta(), l2_DOWN.Phi(), mass2_DOWN, decay2 ));
+      measuredTauLeptonsTauDown.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_tauDOWN.Pt(), l1_tauDOWN.Eta(), l1_tauDOWN.Phi(), mass1_tauDOWN, decay1 ));
+      measuredTauLeptonsTauDown.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_tauDOWN.Pt(), l2_tauDOWN.Eta(), l2_tauDOWN.Phi(), mass2_tauDOWN, decay2 ));
+
+      measuredTauLeptonsEleUp.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_eleUP.Pt(), l1_eleUP.Eta(), l1_eleUP.Phi(), mass1_eleUP, decay1 ));
+      measuredTauLeptonsEleUp.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_eleUP.Pt(), l2_eleUP.Eta(), l2_eleUP.Phi(), mass2_eleUP, decay2 ));
+
+      measuredTauLeptonsEleDown.push_back(classic_svFit::MeasuredTauLepton(l1Type, l1_eleDOWN.Pt(), l1_eleDOWN.Eta(), l1_eleDOWN.Phi(), mass1_eleDOWN, decay1 ));
+      measuredTauLeptonsEleDown.push_back(classic_svFit::MeasuredTauLepton(l2Type, l2_eleDOWN.Pt(), l2_eleDOWN.Eta(), l2_eleDOWN.Phi(), mass2_eleDOWN, decay2 ));
     }
 
     // define algorithm (set the debug level to 3 for testing)
@@ -408,72 +514,96 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
     double SVfitMassTauDown = -999.;
     double SVfitMassMETUp = -999.;
     double SVfitMassMETDown = -999.;
+    double SVfitMassEleUp = -999.;
+    double SVfitMassEleDown = -999.;
 
     double SVfitTransverseMass = -999.;
     double SVfitTransverseMassTauUp = -999.;
     double SVfitTransverseMassTauDown = -999.;
     double SVfitTransverseMassMETUp = -999.;
     double SVfitTransverseMassMETDown = -999.;
+    double SVfitTransverseMassEleUp = -999.;
+    double SVfitTransverseMassEleDown = -999.;
 
     double SVpt = -999.;
     double SVptTauUp = -999.;
     double SVptTauDown = -999.;
     double SVptMETUp = -999.;
     double SVptMETDown = -999.;
+    double SVptEleUp = -999.;
+    double SVptEleDown = -999.;
 
     double SVeta = -999.;
     double SVetaTauUp = -999.;
     double SVetaTauDown = -999.;
     double SVetaMETUp = -999.;
     double SVetaMETDown = -999.;
+    double SVetaEleUp = -999.;
+    double SVetaEleDown = -999.;
 
     double SVphi = -999.;
     double SVphiTauUp = -999.;
     double SVphiTauDown = -999.;
     double SVphiMETUp = -999.;
     double SVphiMETDown = -999.;
+    double SVphiEleUp = -999.;
+    double SVphiEleDown = -999.;
 
     double SVfitMassUnc = -999.;
     double SVfitMassUncTauUp = -999.;
     double SVfitMassUncTauDown = -999.;
     double SVfitMassUncMETUp = -999.;
     double SVfitMassUncMETDown = -999.;
+    double SVfitMassUncEleUp = -999.;
+    double SVfitMassUncEleDown = -999.;
 
     double SVfitTransverseMassUnc = -999.;
     double SVfitTransverseMassUncTauUp = -999.;
     double SVfitTransverseMassUncTauDown = -999.;
     double SVfitTransverseMassUncMETUp = -999.;
     double SVfitTransverseMassUncMETDown = -999.;
+    double SVfitTransverseMassUncEleUp = -999.;
+    double SVfitTransverseMassUncEleDown = -999.;
 
     double SVptUnc = -999.;
     double SVptUncTauUp = -999.;
     double SVptUncTauDown = -999.;
     double SVptUncMETUp = -999.;
     double SVptUncMETDown = -999.;
+    double SVptUncEleUp = -999.;
+    double SVptUncEleDown = -999.;
 
     double SVetaUnc = -999.;
     double SVetaUncTauUp = -999.;
     double SVetaUncTauDown = -999.;
     double SVetaUncMETUp = -999.;
     double SVetaUncMETDown = -999.;
+    double SVetaUncEleUp = -999.;
+    double SVetaUncEleDown = -999.;
 
     double SVphiUnc = -999.;
     double SVphiUncTauUp = -999.;
     double SVphiUncTauDown = -999.;
     double SVphiUncMETUp = -999.;
     double SVphiUncMETDown = -999.;
+    double SVphiUncEleUp = -999.;
+    double SVphiUncEleDown = -999.;
 
     double SVMETRho = -999.;        // fitted MET
     double SVMETRhoTauUp = -999.;   // fitted MET
     double SVMETRhoTauDown = -999.; // fitted MET
     double SVMETRhoMETUp = -999.;   // fitted MET
     double SVMETRhoMETDown = -999.; // fitted MET
+    double SVMETRhoEleUp = -999.;   // fitted MET
+    double SVMETRhoEleDown = -999.; // fitted MET
 
     double SVMETPhi = -999.;        // fitted MET
     double SVMETPhiTauUp = -999.;   // fitted MET
     double SVMETPhiTauDown = -999.; // fitted MET
     double SVMETPhiMETUp = -999.;   // fitted MET
     double SVMETPhiMETDown = -999.; // fitted MET
+    double SVMETPhiEleUp = -999.;   // fitted MET
+    double SVMETPhiEleDown = -999.; // fitted MET
 
     // assessing pair type
     int apdg1 = abs(l1->pdgId());
@@ -542,7 +672,7 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
         SVfitMass = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)
 
       // compute up/down SVfit variations
-      if ( (l1shifted || l2shifted) && _computeForUpDownTES)
+      if ( (l1shifted_tau || l2shifted_tau) && _computeForUpDownTES)
       {
         
         // UP
@@ -566,8 +696,8 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
           SVetaUncTauUp               = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoTauUp.getHistogramAdapter())->getEtaErr();
           SVphiUncTauUp               = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoTauUp.getHistogramAdapter())->getPhiErr();
           
-          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau1Up(l1_UP.Pt(), l1_UP.Eta(), l1_UP.Phi(), mass1);
-          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau2Up(l2_UP.Pt(), l2_UP.Eta(), l2_UP.Phi(), mass2);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau1Up(l1_tauUP.Pt(), l1_tauUP.Eta(), l1_tauUP.Phi(), mass1_tauUP);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau2Up(l2_tauUP.Pt(), l2_tauUP.Eta(), l2_tauUP.Phi(), mass2_tauUP);
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredDiTauSystemUp = measuredTau1Up + measuredTau2Up;
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> fittedDiTauSystemUp(SVptTauUp, SVetaTauUp, SVphiTauUp, SVfitMassTauUp);
           Vector fittedMETUp = (fittedDiTauSystemUp.Vect() - measuredDiTauSystemUp.Vect());
@@ -599,8 +729,8 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
           SVetaUncTauDown               = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoTauDown.getHistogramAdapter())->getEtaErr();
           SVphiUncTauDown               = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoTauDown.getHistogramAdapter())->getPhiErr();
 
-          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau1Down(l1_DOWN.Pt(), l1_DOWN.Eta(), l1_DOWN.Phi(), mass1);
-          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau2Down(l2_DOWN.Pt(), l2_DOWN.Eta(), l2_DOWN.Phi(), mass2);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau1Down(l1_tauDOWN.Pt(), l1_tauDOWN.Eta(), l1_tauDOWN.Phi(), mass1_tauDOWN);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau2Down(l2_tauDOWN.Pt(), l2_tauDOWN.Eta(), l2_tauDOWN.Phi(), mass2_tauDOWN);
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredDiTauSystemDown = measuredTau1Down + measuredTau2Down;
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> fittedDiTauSystemDown(SVptTauDown, SVetaTauDown, SVphiTauDown, SVfitMassTauDown);
           Vector fittedMETDown = (fittedDiTauSystemDown.Vect() - measuredDiTauSystemDown.Vect());
@@ -627,6 +757,86 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
           SVMETPhiTauUp = SVMETPhiTauDown = SVMETPhi ;
       }
 
+      // compute up/down SVfit variations due to e->tau ES
+      if ( (l1shifted_ele || l2shifted_ele) && _computeForUpDownTES)
+      {
+        // UP E->tau ES
+        ClassicSVfit algoEleUp(verbosity);
+        algoEleUp.addLogM_fixed(false, kappa);
+        algoEleUp.addLogM_dynamic(false);
+        algoEleUp.integrate(measuredTauLeptonsEleUp, METx_UP_EES, METy_UP_EES, covMET);
+
+        if ( algoEleUp.isValidSolution() )
+        {
+          SVfitMassEleUp              = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getMass();
+          SVfitTransverseMassEleUp    = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getTransverseMass();
+          SVptEleUp                   = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getPt();
+          SVetaEleUp                  = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getEta();
+          SVphiEleUp                  = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getPhi();
+          SVfitMassUncEleUp           = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getMassErr();
+          SVfitTransverseMassUncEleUp = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getTransverseMassErr();
+          SVptUncEleUp                = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getPtErr();
+          SVetaUncEleUp               = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getEtaErr();
+          SVphiUncEleUp               = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleUp.getHistogramAdapter())->getPhiErr();
+
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau1Up(l1_eleUP.Pt(), l1_eleUP.Eta(), l1_eleUP.Phi(), mass1_eleUP);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau2Up(l2_eleUP.Pt(), l2_eleUP.Eta(), l2_eleUP.Phi(), mass2_eleUP);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredDiTauSystemUp = measuredTau1Up + measuredTau2Up;
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> fittedDiTauSystemUp(SVptEleUp, SVetaEleUp, SVphiEleUp, SVfitMassEleUp);
+          Vector fittedMETUp = (fittedDiTauSystemUp.Vect() - measuredDiTauSystemUp.Vect());
+          SVMETRhoEleUp = fittedMETUp.Rho();
+          SVMETPhiEleUp = fittedMETUp.Phi();
+        }
+        else
+          SVfitMassEleUp = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)
+
+        // DOWN E->tau ES
+        ClassicSVfit algoEleDown(verbosity);
+        algoEleDown.addLogM_fixed(false, kappa);
+        algoEleDown.addLogM_dynamic(false);
+        algoEleDown.integrate(measuredTauLeptonsEleDown, METx_DOWN_EES, METy_DOWN_EES, covMET);
+
+        if ( algoEleDown.isValidSolution() )
+        {
+          SVfitMassEleDown              = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getMass();
+          SVfitTransverseMassEleDown    = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getTransverseMass();
+          SVptEleDown                   = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getPt();
+          SVetaEleDown                  = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getEta();
+          SVphiEleDown                  = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getPhi();
+          SVfitMassUncEleDown           = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getMassErr();
+          SVfitTransverseMassUncEleDown = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getTransverseMassErr();
+          SVptUncEleDown                = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getPtErr();
+          SVetaUncEleDown               = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getEtaErr();
+          SVphiUncEleDown               = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algoEleDown.getHistogramAdapter())->getPhiErr();
+
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau1Down(l1_eleDOWN.Pt(), l1_eleDOWN.Eta(), l1_eleDOWN.Phi(), mass1_eleDOWN);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau2Down(l2_eleDOWN.Pt(), l2_eleDOWN.Eta(), l2_eleDOWN.Phi(), mass2_eleDOWN);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredDiTauSystemDown = measuredTau1Down + measuredTau2Down;
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> fittedDiTauSystemDown(SVptEleDown, SVetaEleDown, SVphiEleDown, SVfitMassEleDown);
+          Vector fittedMETDown = (fittedDiTauSystemDown.Vect() - measuredDiTauSystemDown.Vect());
+          SVMETRhoEleDown = fittedMETDown.Rho();
+          SVMETPhiEleDown = fittedMETDown.Phi();
+        }
+        else
+          SVfitMassEleDown = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)
+
+      }
+      else if (_computeForUpDownTES) // if I asked to have UP/DOWN variation, but this pair has not tau shifted, simply put central value.
+      {                              // instead, if I dindn't ask for up/down, I get -999 everywhere to remember my mistakes
+          SVfitMassEleUp = SVfitMassEleDown = SVfitMass ;
+          SVfitTransverseMassEleUp = SVfitTransverseMassEleDown = SVfitTransverseMass ;
+          SVptEleUp = SVptEleDown = SVpt ;
+          SVetaEleUp = SVetaEleDown = SVeta ;
+          SVphiEleUp = SVphiEleDown = SVphi ;
+          SVfitMassUncEleUp = SVfitMassUncEleDown = SVfitMassUnc ;
+          SVfitTransverseMassUncEleUp = SVfitTransverseMassUncEleDown = SVfitTransverseMassUnc ;
+          SVptUncEleUp = SVptUncEleDown = SVptUnc ;
+          SVetaUncEleUp = SVetaUncEleDown = SVetaUnc ;
+          SVphiUncEleUp = SVphiUncEleDown = SVphiUnc ;
+          SVMETRhoEleUp = SVMETRhoEleDown = SVMETRho ;
+          SVMETPhiEleUp = SVMETPhiEleDown = SVMETPhi ;
+      }
+
       // compute UP/DOWN due to the MET JES shift
       if (_computeForUpDownMET)
       {
@@ -635,7 +845,7 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
         algoMETUp.addLogM_fixed(false, kappa);
         algoMETUp.addLogM_dynamic(false);
         //algoTauUp.shiftVisPt(true, inputFile_visPtResolution_); //not in Classic_svFit
-        algoMETUp.integrate(measuredTauLeptons, METx_UP, METy_UP, covMET);
+        algoMETUp.integrate(measuredTauLeptons, METx_UP_JES, METy_UP_JES, covMET);
 
         if ( algoMETUp.isValidSolution() )
         {
@@ -653,7 +863,7 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau1(l1->pt(), l1->eta(), l1->phi(), mass1);
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau2(l2->pt(), l2->eta(), l2->phi(), mass2);
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredDiTauSystem = measuredTau1 + measuredTau2;
-          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> fittedDiTauSystem(SVpt, SVeta, SVphi, SVfitMass);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> fittedDiTauSystem(SVptMETUp, SVetaMETUp, SVphiMETUp, SVfitMassMETUp);
           Vector fittedMET = (fittedDiTauSystem.Vect() - measuredDiTauSystem.Vect());
           SVMETRhoMETUp = fittedMET.Rho();
           SVMETPhiMETUp = fittedMET.Phi();
@@ -666,7 +876,7 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
         algoMETDown.addLogM_fixed(false, kappa);
         algoMETDown.addLogM_dynamic(false);
         //algoTauUp.shiftVisPt(true, inputFile_visPtResolution_); //not in Classic_svFit
-        algoMETDown.integrate(measuredTauLeptons, METx_DOWN, METy_DOWN, covMET);
+        algoMETDown.integrate(measuredTauLeptons, METx_DOWN_JES, METy_DOWN_JES, covMET);
 
         if ( algoMETDown.isValidSolution() )
         {
@@ -684,13 +894,13 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau1(l1->pt(), l1->eta(), l1->phi(), mass1);
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredTau2(l2->pt(), l2->eta(), l2->phi(), mass2);
           ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> measuredDiTauSystem = measuredTau1 + measuredTau2;
-          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> fittedDiTauSystem(SVpt, SVeta, SVphi, SVfitMass);
+          ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> fittedDiTauSystem(SVptMETDown, SVetaMETDown, SVphiMETDown, SVfitMassMETDown);
           Vector fittedMET = (fittedDiTauSystem.Vect() - measuredDiTauSystem.Vect());
           SVMETRhoMETDown = fittedMET.Rho();
           SVMETPhiMETDown = fittedMET.Phi();
         }
         else
-          SVfitMassMETUp = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)
+          SVfitMassMETDown = -111; // -111: SVfit failed (cfr: -999: SVfit not computed)
       }
 
     } // end of quality checks IF
@@ -707,72 +917,96 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
     pair.addUserFloat("SVfitMassTauDown", (float) SVfitMassTauDown);
     pair.addUserFloat("SVfitMassMETUp", (float) SVfitMassMETUp);
     pair.addUserFloat("SVfitMassMETDown", (float) SVfitMassMETDown);
+    pair.addUserFloat("SVfitMassEleUp", (float) SVfitMassEleUp);
+    pair.addUserFloat("SVfitMassEleDown", (float) SVfitMassEleDown);
 
     pair.addUserFloat("SVfitTransverseMass", (float) SVfitTransverseMass);
     pair.addUserFloat("SVfitTransverseMassTauUp", (float) SVfitTransverseMassTauUp);
     pair.addUserFloat("SVfitTransverseMassTauDown", (float) SVfitTransverseMassTauDown);
     pair.addUserFloat("SVfitTransverseMassMETUp", (float) SVfitTransverseMassMETUp);
     pair.addUserFloat("SVfitTransverseMassMETDown", (float) SVfitTransverseMassMETDown);
+    pair.addUserFloat("SVfitTransverseMassEleUp", (float) SVfitTransverseMassEleUp);
+    pair.addUserFloat("SVfitTransverseMassEleDown", (float) SVfitTransverseMassEleDown);
 
     pair.addUserFloat("SVfit_pt", (float) SVpt);
     pair.addUserFloat("SVfit_ptTauUp", (float) SVptTauUp);
     pair.addUserFloat("SVfit_ptTauDown", (float) SVptTauDown);
     pair.addUserFloat("SVfit_ptMETUp", (float) SVptMETUp);
     pair.addUserFloat("SVfit_ptMETDown", (float) SVptMETDown);
+    pair.addUserFloat("SVfit_ptEleUp", (float) SVptEleUp);
+    pair.addUserFloat("SVfit_ptEleDown", (float) SVptEleDown);
 
     pair.addUserFloat("SVfit_eta", (float) SVeta);
     pair.addUserFloat("SVfit_etaTauUp", (float) SVetaTauUp);
     pair.addUserFloat("SVfit_etaTauDown", (float) SVetaTauDown);
     pair.addUserFloat("SVfit_etaMETUp", (float) SVetaMETUp);
     pair.addUserFloat("SVfit_etaMETDown", (float) SVetaMETDown);
+    pair.addUserFloat("SVfit_etaEleUp", (float) SVetaEleUp);
+    pair.addUserFloat("SVfit_etaEleDown", (float) SVetaEleDown);
 
     pair.addUserFloat("SVfit_phi", (float) SVphi);
     pair.addUserFloat("SVfit_phiTauUp", (float) SVphiTauUp);
     pair.addUserFloat("SVfit_phiTauDown", (float) SVphiTauDown);
     pair.addUserFloat("SVfit_phiMETUp", (float) SVphiMETUp);
     pair.addUserFloat("SVfit_phiMETDown", (float) SVphiMETDown);
+    pair.addUserFloat("SVfit_phiEleUp", (float) SVphiEleUp);
+    pair.addUserFloat("SVfit_phiEleDown", (float) SVphiEleDown);
 
     pair.addUserFloat("SVfitMassUnc", (float) SVfitMassUnc);
     pair.addUserFloat("SVfitMassUncTauUp", (float) SVfitMassUncTauUp);
     pair.addUserFloat("SVfitMassUncTauDown", (float) SVfitMassUncTauDown);
     pair.addUserFloat("SVfitMassUncMETUp", (float) SVfitMassUncMETUp);
     pair.addUserFloat("SVfitMassUncMETDown", (float) SVfitMassUncMETDown);
+    pair.addUserFloat("SVfitMassUncEleUp", (float) SVfitMassUncEleUp);
+    pair.addUserFloat("SVfitMassUncEleDown", (float) SVfitMassUncEleDown);
 
     pair.addUserFloat("SVfitTransverseMassUnc", (float) SVfitTransverseMassUnc);
     pair.addUserFloat("SVfitTransverseMassUncTauUp", (float) SVfitTransverseMassUncTauUp);
     pair.addUserFloat("SVfitTransverseMassUncTauDown", (float) SVfitTransverseMassUncTauDown);
     pair.addUserFloat("SVfitTransverseMassUncMETUp", (float) SVfitTransverseMassUncMETUp);
     pair.addUserFloat("SVfitTransverseMassUncMETDown", (float) SVfitTransverseMassUncMETDown);
+    pair.addUserFloat("SVfitTransverseMassUncEleUp", (float) SVfitTransverseMassUncEleUp);
+    pair.addUserFloat("SVfitTransverseMassUncEleDown", (float) SVfitTransverseMassUncEleDown);
 
     pair.addUserFloat("SVfit_ptUnc", (float) SVptUnc);
     pair.addUserFloat("SVfit_ptUncTauUp", (float) SVptUncTauUp);
     pair.addUserFloat("SVfit_ptUncTauDown", (float) SVptUncTauDown);
     pair.addUserFloat("SVfit_ptUncMETUp", (float) SVptUncMETUp);
     pair.addUserFloat("SVfit_ptUncMETDown", (float) SVptUncMETDown);
+    pair.addUserFloat("SVfit_ptUncEleUp", (float) SVptUncEleUp);
+    pair.addUserFloat("SVfit_ptUncEleDown", (float) SVptUncEleDown);
 
     pair.addUserFloat("SVfit_etaUnc", (float) SVetaUnc);
     pair.addUserFloat("SVfit_etaUncTauUp", (float) SVetaUncTauUp);
     pair.addUserFloat("SVfit_etaUncTauDown", (float) SVetaUncTauDown);
     pair.addUserFloat("SVfit_etaUncMETUp", (float) SVetaUncMETUp);
     pair.addUserFloat("SVfit_etaUncMETDown", (float) SVetaUncMETDown);
+    pair.addUserFloat("SVfit_etaUncEleUp", (float) SVetaUncEleUp);
+    pair.addUserFloat("SVfit_etaUncEleDown", (float) SVetaUncEleDown);
 
     pair.addUserFloat("SVfit_phiUnc", (float) SVphiUnc);
     pair.addUserFloat("SVfit_phiUncTauUp", (float) SVphiUncTauUp);
     pair.addUserFloat("SVfit_phiUncTauDown", (float) SVphiUncTauDown);
     pair.addUserFloat("SVfit_phiUncMETUp", (float) SVphiUncMETUp);
     pair.addUserFloat("SVfit_phiUncMETDown", (float) SVphiUncMETDown);
+    pair.addUserFloat("SVfit_phiUncEleUp", (float) SVphiUncEleUp);
+    pair.addUserFloat("SVfit_phiUncEleDown", (float) SVphiUncEleDown);
 
     pair.addUserFloat("SVfit_METRho", (float) SVMETRho);
     pair.addUserFloat("SVfit_METRhoTauUp", (float) SVMETRhoTauUp);
     pair.addUserFloat("SVfit_METRhoTauDown", (float) SVMETRhoTauDown);
     pair.addUserFloat("SVfit_METRhoMETUp", (float) SVMETRhoMETUp);
     pair.addUserFloat("SVfit_METRhoMETDown", (float) SVMETRhoMETDown);
+    pair.addUserFloat("SVfit_METRhoEleUp", (float) SVMETRhoEleUp);
+    pair.addUserFloat("SVfit_METRhoEleDown", (float) SVMETRhoEleDown);
 
     pair.addUserFloat("SVfit_METPhi", (float) SVMETPhi);
     pair.addUserFloat("SVfit_METPhiTauUp", (float) SVMETPhiTauUp);
     pair.addUserFloat("SVfit_METPhiTauDown", (float) SVMETPhiTauDown);
     pair.addUserFloat("SVfit_METPhiMETUp", (float) SVMETPhiMETUp);
     pair.addUserFloat("SVfit_METPhiMETDown", (float) SVMETPhiMETDown);
+    pair.addUserFloat("SVfit_METPhiEleUp", (float) SVMETPhiEleUp);
+    pair.addUserFloat("SVfit_METPhiEleDown", (float) SVMETPhiEleDown);
 
     pair.addUserFloat("MEt_px", (float) METx);
     pair.addUserFloat("MEt_py", (float) METy);
@@ -783,16 +1017,20 @@ void ClassicSVfitInterface::produce(edm::Event& iEvent, const edm::EventSetup& i
     pair.addUserFloat("MEt_cov10", (float) covMET[1][0]);
     pair.addUserFloat("MEt_cov11", (float) covMET[1][1]);
     pair.addUserFloat("MEt_significance", significance);
-    pair.addUserFloat("MEt_px_UP", (float) METx_UP);
-    pair.addUserFloat("MEt_py_UP", (float) METy_UP);
-    pair.addUserFloat("MEt_px_DOWN", (float) METx_DOWN);
-    pair.addUserFloat("MEt_py_DOWN", (float) METy_DOWN);
+    pair.addUserFloat("MEt_px_UP_JES", (float) METx_UP_JES);
+    pair.addUserFloat("MEt_py_UP_JES", (float) METy_UP_JES);
+    pair.addUserFloat("MEt_px_DOWN_JES", (float) METx_DOWN_JES);
+    pair.addUserFloat("MEt_py_DOWN_JES", (float) METy_DOWN_JES);
     pair.addUserFloat("MEt_px_UP_TES", (float) METx_UP_TES);
     pair.addUserFloat("MEt_py_UP_TES", (float) METy_UP_TES);
     pair.addUserFloat("MEt_px_DOWN_TES", (float) METx_DOWN_TES);
     pair.addUserFloat("MEt_py_DOWN_TES", (float) METy_DOWN_TES);
+    pair.addUserFloat("MEt_px_UP_EES", (float) METx_UP_EES);
+    pair.addUserFloat("MEt_py_UP_EES", (float) METy_UP_EES);
+    pair.addUserFloat("MEt_px_DOWN_EES", (float) METx_DOWN_EES);
+    pair.addUserFloat("MEt_py_DOWN_EES", (float) METy_DOWN_EES);
 
-    result->push_back(pair);     
+    result->push_back(pair);
   }
   
   iEvent.put(std::move(result));

--- a/NtupleProducer/plugins/ClassicSVfitInterface.cc
+++ b/NtupleProducer/plugins/ClassicSVfitInterface.cc
@@ -1106,7 +1106,8 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
   ///////
 
   // switch to apply different requirements to the objects
-  if (deltaR(l1->p4(), l2->p4()) < 0.1)
+  //if (deltaR(l1->p4(), l2->p4()) < 0.1)
+  if (deltaR(l1->p4(), l2->p4()) < 0.4)
     return false; // for overlap removal
 
   ///////
@@ -1120,7 +1121,8 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
     dau1 = (apdg1 == 13 ? l1 : l2);
     dau2 = (apdg1 == 13 ? l2 : l1);
 
-    if (dau1->pt() < 17.)
+    //if (dau1->pt() < 17.)
+    if (dau1->pt() < 20.)
       return false;
 
     if (dau2->pt() < 20.)
@@ -1129,10 +1131,12 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
     if (userdatahelpers::getUserInt(l2,"decayModeFindingNewDMs") != 1) // decayModeFinding == decayModeFindingOldDMs
       return false;
 
-    bool iso1 = (userdatahelpers::getUserFloat(l1,"combRelIsoPF") < 0.3);
+    //bool iso1 = (userdatahelpers::getUserFloat(l1,"combRelIsoPF") < 0.3);
+    bool iso1 = (userdatahelpers::getUserFloat(l1,"combRelIsoPF") < 0.2);
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVLooseIsolationMVArun2v1DBoldDMwLT") == 1);
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseIsolationMVArun2017v2DBoldDMwLT2017") == 1); //FRA 2017
-    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1); //FRA 2017
+    //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
+    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseDeepTau2017v2p1VSjet") == 1);
 
     if (!iso1 || !iso2)
       return false;
@@ -1145,7 +1149,8 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
     dau1 = (apdg1 == 11 ? l1 : l2);
     dau2 = (apdg1 == 11 ? l2 : l1);
 
-    if (dau1->pt() < 19.)
+    //if (dau1->pt() < 19.)
+    if (dau1->pt() < 20.)
       return false;
 
     if (dau2->pt() < 20.)
@@ -1154,10 +1159,12 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
     if (userdatahelpers::getUserInt(l2,"decayModeFindingNewDMs") != 1)  // decayModeFinding == decayModeFindingOldDMs
       return false;
 
-    bool iso1 = (userdatahelpers::getUserFloat(l1,"combRelIsoPF") < 0.3);
+    //bool iso1 = (userdatahelpers::getUserFloat(l1,"combRelIsoPF") < 0.3);
+    bool iso1 = (userdatahelpers::getUserFloat(l1,"combRelIsoPF") < 0.2);
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVLooseIsolationMVArun2v1DBoldDMwLT") == 1);
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseIsolationMVArun2017v2DBoldDMwLT2017") == 1); //FRA 2017
-    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1); //FRA 2017
+    //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
+    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseDeepTau2017v2p1VSjet") == 1);
 
     if (!iso1 || !iso2)
       return false;
@@ -1188,8 +1195,10 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVLooseIsolationMVArun2v1DBoldDMwLT") == 1);
     //bool iso1 = (userdatahelpers::getUserInt(l1,"byVVLooseIsolationMVArun2017v2DBoldDMwLT2017") == 1); //FRA 2017
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseIsolationMVArun2017v2DBoldDMwLT2017") == 1); //FRA 2017
-    bool iso1 = (userdatahelpers::getUserInt(l1,"byVVVLooseDeepTau2017v2p1VSjet") == 1); //FRA 2017
-    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1); //FRA 2017
+    //bool iso1 = (userdatahelpers::getUserInt(l1,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
+    //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
+    bool iso1 = (userdatahelpers::getUserInt(l1,"byVVLooseDeepTau2017v2p1VSjet") == 1);
+    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseDeepTau2017v2p1VSjet") == 1);
 
     if (!iso1 || !iso2)
       return false;

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -575,7 +575,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Int_t> _decayType;//for taus only
   std::vector<Int_t> _genmatch;//for taus only
   std::vector<Long64_t> _daughters_tauID; //bitwise. check h_tauID for histogram list 
-  static const int ntauIds = 61;
+  static const int ntauIds = 37;
   TString tauIDStrings[ntauIds] = {
    "byLooseCombinedIsolationDeltaBetaCorr3Hits",
    "byMediumCombinedIsolationDeltaBetaCorr3Hits",
@@ -587,25 +587,25 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
    "againstElectronMediumMVA6",
    "againstElectronTightMVA6",
    "againstElectronVTightMVA6",
-   "byVLooseIsolationMVArun2v1DBoldDMwLT",
-   "byLooseIsolationMVArun2v1DBoldDMwLT",
-   "byMediumIsolationMVArun2v1DBoldDMwLT",
-   "byTightIsolationMVArun2v1DBoldDMwLT",
-   "byVTightIsolationMVArun2v1DBoldDMwLT",
-   "byVLooseIsolationMVArun2v1DBnewDMwLT",
-   "byLooseIsolationMVArun2v1DBnewDMwLT",
-   "byMediumIsolationMVArun2v1DBnewDMwLT",
-   "byTightIsolationMVArun2v1DBnewDMwLT",
-   "byVTightIsolationMVArun2v1DBnewDMwLT",
-   "byLooseIsolationMVArun2v1DBdR03oldDMwLT",
-   "byMediumIsolationMVArun2v1DBdR03oldDMwLT",
-   "byTightIsolationMVArun2v1DBdR03oldDMwLT",
-   "byVTightIsolationMVArun2v1DBdR03oldDMwLT",
-   "byVLooseIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
-   "byLooseIsolationMVArun2017v1DBoldDMwLT2017",  //FRA syncApr2018
-   "byMediumIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
-   "byTightIsolationMVArun2017v1DBoldDMwLT2017",  //FRA syncApr2018
-   "byVTightIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
+   //"byVLooseIsolationMVArun2v1DBoldDMwLT",
+   //"byLooseIsolationMVArun2v1DBoldDMwLT",
+   //"byMediumIsolationMVArun2v1DBoldDMwLT",
+   //"byTightIsolationMVArun2v1DBoldDMwLT",
+   //"byVTightIsolationMVArun2v1DBoldDMwLT",
+   //"byVLooseIsolationMVArun2v1DBnewDMwLT",
+   //"byLooseIsolationMVArun2v1DBnewDMwLT",
+   //"byMediumIsolationMVArun2v1DBnewDMwLT",
+   //"byTightIsolationMVArun2v1DBnewDMwLT",
+   //"byVTightIsolationMVArun2v1DBnewDMwLT",
+   //"byLooseIsolationMVArun2v1DBdR03oldDMwLT",
+   //"byMediumIsolationMVArun2v1DBdR03oldDMwLT",
+   //"byTightIsolationMVArun2v1DBdR03oldDMwLT",
+   //"byVTightIsolationMVArun2v1DBdR03oldDMwLT",
+   //"byVLooseIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
+   //"byLooseIsolationMVArun2017v1DBoldDMwLT2017",  //FRA syncApr2018
+   //"byMediumIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
+   //"byTightIsolationMVArun2017v1DBoldDMwLT2017",  //FRA syncApr2018
+   //"byVTightIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
    "byVVLooseIsolationMVArun2017v2DBoldDMwLT2017", //FRA syncApr2018
    "byVLooseIsolationMVArun2017v2DBoldDMwLT2017", //FRA syncApr2018
    "byLooseIsolationMVArun2017v2DBoldDMwLT2017",  //FRA syncApr2018
@@ -613,14 +613,14 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
    "byTightIsolationMVArun2017v2DBoldDMwLT2017",  //FRA syncApr2018
    "byVTightIsolationMVArun2017v2DBoldDMwLT2017", //FRA syncApr2018
    "byVVTightIsolationMVArun2017v2DBoldDMwLT2017", //FRA syncApr2018
-   "byVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
-   "byLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
-   "byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
-   "byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
-   "byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
+   //"byVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
+   //"byLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
+   //"byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
+   //"byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
+   //"byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
    "byVVVLooseDeepTau2017v2p1VSjet",
    "byVVLooseDeepTau2017v2p1VSjet", 
-   "byVLooseDeepTau2017v2p1VSjet",  
+   "byVLooseDeepTau2017v2p1VSjet",
    "byLooseDeepTau2017v2p1VSjet",   
    "byMediumDeepTau2017v2p1VSjet",  
    "byTightDeepTau2017v2p1VSjet",   
@@ -630,7 +630,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
    "byVVLooseDeepTau2017v2p1VSe", 
    "byVLooseDeepTau2017v2p1VSe",   
    "byLooseDeepTau2017v2p1VSe",	
-   "byMediumDeepTau2017v2p1VSe",   
+   "byMediumDeepTau2017v2p1VSe",
    "byTightDeepTau2017v2p1VSe",	
    "byVTightDeepTau2017v2p1VSe",   
    "byVVTightDeepTau2017v2p1VSe",   
@@ -656,10 +656,10 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _daughters_photonPtSumOutsideSignalCone;
   std::vector<Int_t> _daughters_decayModeFindingNewDMs;
   std::vector<Float_t> _daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits;
-  std::vector<Float_t> _daughters_byIsolationMVArun2v1DBoldDMwLTraw;
+  //std::vector<Float_t> _daughters_byIsolationMVArun2v1DBoldDMwLTraw;
   std::vector<Float_t> _daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017; //FRA
-  std::vector<Float_t> _daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017; //FRA
-  std::vector<Float_t> _daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017; //FRA
+  //std::vector<Float_t> _daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017; //FRA
+  //std::vector<Float_t> _daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017; //FRA
   std::vector<Float_t> _daughters_byDeepTau2017v2p1VSjetraw;
   std::vector<Float_t> _daughters_byDeepTau2017v2p1VSeraw;
   std::vector<Float_t> _daughters_byDeepTau2017v2p1VSmuraw;
@@ -1148,10 +1148,10 @@ void HTauTauNtuplizer::Initialize(){
   _daughters_decayModeFindingOldDMs.clear();
   _daughters_decayModeFindingNewDMs.clear();
   _daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits.clear();
-  _daughters_byIsolationMVArun2v1DBoldDMwLTraw.clear();
+  //_daughters_byIsolationMVArun2v1DBoldDMwLTraw.clear();
   _daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017.clear();      //FRA
-  _daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017.clear();      //FRA
-  _daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017.clear(); //FRA
+  //_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017.clear();      //FRA
+  //_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017.clear(); //FRA
   _daughters_byDeepTau2017v2p1VSjetraw.clear();
   _daughters_byDeepTau2017v2p1VSeraw.clear();
   _daughters_byDeepTau2017v2p1VSmuraw.clear();
@@ -1940,10 +1940,10 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("photonPtSumOutsideSignalCone",&_daughters_photonPtSumOutsideSignalCone);
   myTree->Branch("daughters_decayModeFindingNewDMs", &_daughters_decayModeFindingNewDMs);
   myTree->Branch("daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits", &_daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits);
-  myTree->Branch("daughters_byIsolationMVArun2v1DBoldDMwLTraw",&_daughters_byIsolationMVArun2v1DBoldDMwLTraw);
+  //myTree->Branch("daughters_byIsolationMVArun2v1DBoldDMwLTraw",&_daughters_byIsolationMVArun2v1DBoldDMwLTraw);
   myTree->Branch("daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017",&_daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017); //FRA
-  myTree->Branch("daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017",&_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017); //FRA
-  myTree->Branch("daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017",&_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017); //FRA
+  //myTree->Branch("daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017",&_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017); //FRA
+  //myTree->Branch("daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017",&_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017); //FRA
   myTree->Branch("daughters_byDeepTau2017v2p1VSjetraw",&_daughters_byDeepTau2017v2p1VSjetraw);
   myTree->Branch("daughters_byDeepTau2017v2p1VSeraw",&_daughters_byDeepTau2017v2p1VSeraw);
   myTree->Branch("daughters_byDeepTau2017v2p1VSmuraw",&_daughters_byDeepTau2017v2p1VSmuraw);
@@ -3560,7 +3560,8 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     int numChargedParticlesSignalCone=-1, numNeutralHadronsSignalCone=-1, numPhotonsSignalCone=-1, numParticlesSignalCone=-1, numChargedParticlesIsoCone=-1, numNeutralHadronsIsoCone=-1, numPhotonsIsoCone=-1, numParticlesIsoCone=-1;
     float leadChargedParticlePt=-1., trackRefPt=-1.;
     int typeOfMuon=0;
-    float byIsolationMVArun2v1DBoldDMwLTraw=-1, byIsolationMVArun2017v2DBoldDMwLTraw2017=-1, byIsolationMVArun2017v1DBoldDMwLTraw2017=-1, byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017=-1; //FRA
+    //float byIsolationMVArun2v1DBoldDMwLTraw=-1, byIsolationMVArun2017v2DBoldDMwLTraw2017=-1, byIsolationMVArun2017v1DBoldDMwLTraw2017=-1, byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017=-1; //FRA
+    float byIsolationMVArun2017v2DBoldDMwLTraw2017=-1; //FRA
     float byDeepTau2017v2p1VSjetraw=-1, byDeepTau2017v2p1VSeraw=-1, byDeepTau2017v2p1VSmuraw=-1;
     int  byVVLooseIsolationMVArun2017v2DBoldDMwLT2017=-1; //FRA
     Long64_t tauIDflag = 0;
@@ -3668,10 +3669,10 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
       photonPtSumOutsideSignalCone = userdatahelpers::getUserFloat (cand, "photonPtSumOutsideSignalCone");
 
       byCombinedIsolationDeltaBetaCorrRaw3Hits = userdatahelpers::getUserFloat (cand, "byCombinedIsolationDeltaBetaCorrRaw3Hits");
-      byIsolationMVArun2v1DBoldDMwLTraw=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2v1DBoldDMwLTraw");
+      //byIsolationMVArun2v1DBoldDMwLTraw=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2v1DBoldDMwLTraw");
       byIsolationMVArun2017v2DBoldDMwLTraw2017=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2017v2DBoldDMwLTraw2017"); //FRA
-      byIsolationMVArun2017v1DBoldDMwLTraw2017=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2017v1DBoldDMwLTraw2017"); //FRA
-      byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017"); //FRA
+      //byIsolationMVArun2017v1DBoldDMwLTraw2017=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2017v1DBoldDMwLTraw2017"); //FRA
+      //byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017=userdatahelpers::getUserFloat (cand, "byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017"); //FRA
       byDeepTau2017v2p1VSjetraw=userdatahelpers::getUserFloat(cand,"byDeepTau2017v2p1VSjetraw");
       byDeepTau2017v2p1VSeraw=userdatahelpers::getUserFloat(cand,"byDeepTau2017v2p1VSeraw");
       byDeepTau2017v2p1VSmuraw=userdatahelpers::getUserFloat(cand,"byDeepTau2017v2p1VSmuraw");
@@ -3747,10 +3748,10 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     _daughters_chargedIsoPtSum.push_back(chargedIsoPtSum);
     _daughters_neutralIsoPtSum.push_back(neutralIsoPtSum);
     _daughters_puCorrPtSum.push_back(puCorrPtSum);
-    _daughters_byIsolationMVArun2v1DBoldDMwLTraw.push_back(byIsolationMVArun2v1DBoldDMwLTraw);
+    //_daughters_byIsolationMVArun2v1DBoldDMwLTraw.push_back(byIsolationMVArun2v1DBoldDMwLTraw);
     _daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017.push_back(byIsolationMVArun2017v2DBoldDMwLTraw2017); //FRA
-    _daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017.push_back(byIsolationMVArun2017v1DBoldDMwLTraw2017); //FRA
-    _daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017.push_back(byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017); //FRA
+    //_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017.push_back(byIsolationMVArun2017v1DBoldDMwLTraw2017); //FRA
+    //_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017.push_back(byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017); //FRA
     _daughters_byDeepTau2017v2p1VSjetraw.push_back(byDeepTau2017v2p1VSjetraw);
     _daughters_byDeepTau2017v2p1VSeraw.push_back(byDeepTau2017v2p1VSeraw);
     _daughters_byDeepTau2017v2p1VSmuraw.push_back(byDeepTau2017v2p1VSmuraw);

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -428,72 +428,96 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _SVmassTauDown;
   std::vector<Float_t> _SVmassMETUp;
   std::vector<Float_t> _SVmassMETDown;
+  std::vector<Float_t> _SVmassEleUp;
+  std::vector<Float_t> _SVmassEleDown;
 
   std::vector<Float_t> _SVmassUnc;
   std::vector<Float_t> _SVmassUncTauUp;
   std::vector<Float_t> _SVmassUncTauDown;
   std::vector<Float_t> _SVmassUncMETUp;
   std::vector<Float_t> _SVmassUncMETDown;
+  std::vector<Float_t> _SVmassUncEleUp;
+  std::vector<Float_t> _SVmassUncEleDown;
 
   std::vector<Float_t> _SVmassTransverse;
   std::vector<Float_t> _SVmassTransverseTauUp;
   std::vector<Float_t> _SVmassTransverseTauDown;
   std::vector<Float_t> _SVmassTransverseMETUp;
   std::vector<Float_t> _SVmassTransverseMETDown;
+  std::vector<Float_t> _SVmassTransverseEleUp;
+  std::vector<Float_t> _SVmassTransverseEleDown;
 
   std::vector<Float_t> _SVmassTransverseUnc;
   std::vector<Float_t> _SVmassTransverseUncTauUp;
   std::vector<Float_t> _SVmassTransverseUncTauDown;
   std::vector<Float_t> _SVmassTransverseUncMETUp;
   std::vector<Float_t> _SVmassTransverseUncMETDown;
+  std::vector<Float_t> _SVmassTransverseUncEleUp;
+  std::vector<Float_t> _SVmassTransverseUncEleDown;
 
   std::vector<Float_t> _SVpt;
   std::vector<Float_t> _SVptTauUp;
   std::vector<Float_t> _SVptTauDown;
   std::vector<Float_t> _SVptMETUp;
   std::vector<Float_t> _SVptMETDown;
+  std::vector<Float_t> _SVptEleUp;
+  std::vector<Float_t> _SVptEleDown;
 
   std::vector<Float_t> _SVptUnc;
   std::vector<Float_t> _SVptUncTauUp;
   std::vector<Float_t> _SVptUncTauDown;
   std::vector<Float_t> _SVptUncMETUp;
   std::vector<Float_t> _SVptUncMETDown;
+  std::vector<Float_t> _SVptUncEleUp;
+  std::vector<Float_t> _SVptUncEleDown;
 
   std::vector<Float_t> _SVeta;
   std::vector<Float_t> _SVetaTauUp;
   std::vector<Float_t> _SVetaTauDown;
   std::vector<Float_t> _SVetaMETUp;
   std::vector<Float_t> _SVetaMETDown;
+  std::vector<Float_t> _SVetaEleUp;
+  std::vector<Float_t> _SVetaEleDown;
 
   std::vector<Float_t> _SVetaUnc;
   std::vector<Float_t> _SVetaUncTauUp;
   std::vector<Float_t> _SVetaUncTauDown;
   std::vector<Float_t> _SVetaUncMETUp;
   std::vector<Float_t> _SVetaUncMETDown;
+  std::vector<Float_t> _SVetaUncEleUp;
+  std::vector<Float_t> _SVetaUncEleDown;
 
   std::vector<Float_t> _SVphi;
   std::vector<Float_t> _SVphiTauUp;
   std::vector<Float_t> _SVphiTauDown;
   std::vector<Float_t> _SVphiMETUp;
   std::vector<Float_t> _SVphiMETDown;
+  std::vector<Float_t> _SVphiEleUp;
+  std::vector<Float_t> _SVphiEleDown;
 
   std::vector<Float_t> _SVphiUnc;
   std::vector<Float_t> _SVphiUncTauUp;
   std::vector<Float_t> _SVphiUncTauDown;
   std::vector<Float_t> _SVphiUncMETUp;
   std::vector<Float_t> _SVphiUncMETDown;
+  std::vector<Float_t> _SVphiUncEleUp;
+  std::vector<Float_t> _SVphiUncEleDown;
 
   std::vector<Float_t> _SVMetRho;
   std::vector<Float_t> _SVMetRhoTauUp;
   std::vector<Float_t> _SVMetRhoTauDown;
   std::vector<Float_t> _SVMetRhoMETUp;
   std::vector<Float_t> _SVMetRhoMETDown;
+  std::vector<Float_t> _SVMetRhoEleUp;
+  std::vector<Float_t> _SVMetRhoEleDown;
 
   std::vector<Float_t> _SVMetPhi;
   std::vector<Float_t> _SVMetPhiTauUp;
   std::vector<Float_t> _SVMetPhiTauDown;
   std::vector<Float_t> _SVMetPhiMETUp;
   std::vector<Float_t> _SVMetPhiMETDown;
+  std::vector<Float_t> _SVMetPhiEleUp;
+  std::vector<Float_t> _SVMetPhiEleDown;
 
   std::vector<Float_t> _metx;
   std::vector<Float_t> _mety;
@@ -1255,72 +1279,96 @@ void HTauTauNtuplizer::Initialize(){
   _SVmassTauDown.clear();
   _SVmassMETUp.clear();
   _SVmassMETDown.clear();
+  _SVmassEleUp.clear();
+  _SVmassEleDown.clear();
 
   _SVmassUnc.clear();
   _SVmassUncTauUp.clear();
   _SVmassUncTauDown.clear();
   _SVmassUncMETUp.clear();
   _SVmassUncMETDown.clear();
+  _SVmassUncEleUp.clear();
+  _SVmassUncEleDown.clear();
 
   _SVmassTransverse.clear();
   _SVmassTransverseTauUp.clear();
   _SVmassTransverseTauDown.clear();
   _SVmassTransverseMETUp.clear();
   _SVmassTransverseMETDown.clear();
+  _SVmassTransverseEleUp.clear();
+  _SVmassTransverseEleDown.clear();
 
   _SVmassTransverseUnc.clear();
   _SVmassTransverseUncTauUp.clear();
   _SVmassTransverseUncTauDown.clear();
   _SVmassTransverseUncMETUp.clear();
   _SVmassTransverseUncMETDown.clear();
+  _SVmassTransverseUncEleUp.clear();
+  _SVmassTransverseUncEleDown.clear();
 
   _SVpt.clear();
   _SVptTauUp.clear();
   _SVptTauDown.clear();
   _SVptMETUp.clear();
   _SVptMETDown.clear();
+  _SVptEleUp.clear();
+  _SVptEleDown.clear();
 
   _SVptUnc.clear();
   _SVptUncTauUp.clear();
   _SVptUncTauDown.clear();
   _SVptUncMETUp.clear();
   _SVptUncMETDown.clear();
+  _SVptUncEleUp.clear();
+  _SVptUncEleDown.clear();
 
   _SVeta.clear();
   _SVetaTauUp.clear();
   _SVetaTauDown.clear();
   _SVetaMETUp.clear();
   _SVetaMETDown.clear();
+  _SVetaEleUp.clear();
+  _SVetaEleDown.clear();
 
   _SVetaUnc.clear();
   _SVetaUncTauUp.clear();
   _SVetaUncTauDown.clear();
   _SVetaUncMETUp.clear();
   _SVetaUncMETDown.clear();
+  _SVetaUncEleUp.clear();
+  _SVetaUncEleDown.clear();
 
   _SVphi.clear();
   _SVphiTauUp.clear();
   _SVphiTauDown.clear();
   _SVphiMETUp.clear();
   _SVphiMETDown.clear();
+  _SVphiEleUp.clear();
+  _SVphiEleDown.clear();
 
   _SVphiUnc.clear();
   _SVphiUncTauUp.clear();
   _SVphiUncTauDown.clear();
   _SVphiUncMETUp.clear();
   _SVphiUncMETDown.clear();
+  _SVphiUncEleUp.clear();
+  _SVphiUncEleDown.clear();
 
   _SVMetRho.clear();
   _SVMetRhoTauUp.clear();
   _SVMetRhoTauDown.clear();
   _SVMetRhoMETUp.clear();
   _SVMetRhoMETDown.clear();
+  _SVMetRhoEleUp.clear();
+  _SVMetRhoEleDown.clear();
 
   _SVMetPhi.clear();
   _SVMetPhiTauUp.clear();
   _SVMetPhiTauDown.clear();
   _SVMetPhiMETUp.clear();
   _SVMetPhiMETDown.clear();
+  _SVMetPhiEleUp.clear();
+  _SVMetPhiEleDown.clear();
 
   _isOSCand.clear();
   _daughters_HLTpt.clear();
@@ -1739,52 +1787,78 @@ void HTauTauNtuplizer::beginJob(){
     myTree->Branch("NUP", &_nup,"NUP/I");
     myTree->Branch("SVfit_fitMETPhiTauUp", &_SVMetPhiTauUp);
     myTree->Branch("SVfit_fitMETPhiTauDown", &_SVMetPhiTauDown);
-    myTree->Branch("SVfit_fitMETPhiMETUp", &_SVMetPhiMETUp);
-    myTree->Branch("SVfit_fitMETPhiMETDown", &_SVMetPhiMETDown);
     myTree->Branch("SVfit_fitMETRhoTauUp", &_SVMetRhoTauUp);
     myTree->Branch("SVfit_fitMETRhoTauDown", &_SVMetRhoTauDown);
-    myTree->Branch("SVfit_fitMETRhoMETUp", &_SVMetRhoMETUp);
-    myTree->Branch("SVfit_fitMETRhoMETDown", &_SVMetRhoMETDown);
     myTree->Branch("SVfit_phiUncTauUp", &_SVphiUncTauUp);
     myTree->Branch("SVfit_phiUncTauDown", &_SVphiUncTauDown);
-    myTree->Branch("SVfit_phiUncMETUp", &_SVphiUncMETUp);
-    myTree->Branch("SVfit_phiUncMETDown", &_SVphiUncMETDown);
     myTree->Branch("SVfit_phiTauUp", &_SVphiTauUp);
     myTree->Branch("SVfit_phiTauDown", &_SVphiTauDown);
-    myTree->Branch("SVfit_phiMETUp", &_SVphiMETUp);
-    myTree->Branch("SVfit_phiMETDown", &_SVphiMETDown);
     myTree->Branch("SVfit_etaUncTauUp", &_SVetaUncTauUp);
     myTree->Branch("SVfit_etaUncTauDown", &_SVetaUncTauDown);
-    myTree->Branch("SVfit_etaUncMETUp", &_SVetaUncMETUp);
-    myTree->Branch("SVfit_etaUncMETDown", &_SVetaUncMETDown);
     myTree->Branch("SVfit_etaTauUp", &_SVetaTauUp);
     myTree->Branch("SVfit_etaTauDown", &_SVetaTauDown);
-    myTree->Branch("SVfit_etaMETUp", &_SVetaMETUp);
-    myTree->Branch("SVfit_etaMETDown", &_SVetaMETDown);
     myTree->Branch("SVfit_ptUncTauUp", &_SVptUncTauUp);
     myTree->Branch("SVfit_ptUncTauDown", &_SVptUncTauDown);
-    myTree->Branch("SVfit_ptUncMETUp", &_SVptUncMETUp);
-    myTree->Branch("SVfit_ptUncMETDown", &_SVptUncMETDown);
     myTree->Branch("SVfit_ptTauUp", &_SVptTauUp);
     myTree->Branch("SVfit_ptTauDown", &_SVptTauDown);
-    myTree->Branch("SVfit_ptMETUp", &_SVptMETUp);
-    myTree->Branch("SVfit_ptMETDown", &_SVptMETDown);
     myTree->Branch("SVfitTransverseMassUncTauUp",&_SVmassTransverseUncTauUp);
     myTree->Branch("SVfitTransverseMassUncTauDown",&_SVmassTransverseUncTauDown);
-    myTree->Branch("SVfitTransverseMassUncMETUp",&_SVmassTransverseUncMETUp);
-    myTree->Branch("SVfitTransverseMassUncMETDown",&_SVmassTransverseUncMETDown);
     myTree->Branch("SVfitTransverseMassTauUp",&_SVmassTransverseTauUp);
     myTree->Branch("SVfitTransverseMassTauDown",&_SVmassTransverseTauDown);
-    myTree->Branch("SVfitTransverseMassMETUp",&_SVmassTransverseMETUp);
-    myTree->Branch("SVfitTransverseMassMETDown",&_SVmassTransverseMETDown);
     myTree->Branch("SVfitMassUncTauUp",&_SVmassUncTauUp);
     myTree->Branch("SVfitMassUncTauDown",&_SVmassUncTauDown);
-    myTree->Branch("SVfitMassUncMETUp",&_SVmassUncMETUp);
-    myTree->Branch("SVfitMassUncMETDown",&_SVmassUncMETDown);
     myTree->Branch("SVfitMassTauUp",&_SVmassTauUp);
     myTree->Branch("SVfitMassTauDown",&_SVmassTauDown);
+
+    myTree->Branch("SVfit_fitMETPhiMETUp", &_SVMetPhiMETUp);
+    myTree->Branch("SVfit_fitMETPhiMETDown", &_SVMetPhiMETDown);
+    myTree->Branch("SVfit_fitMETRhoMETUp", &_SVMetRhoMETUp);
+    myTree->Branch("SVfit_fitMETRhoMETDown", &_SVMetRhoMETDown);
+    myTree->Branch("SVfit_phiUncMETUp", &_SVphiUncMETUp);
+    myTree->Branch("SVfit_phiUncMETDown", &_SVphiUncMETDown);
+    myTree->Branch("SVfit_phiMETUp", &_SVphiMETUp);
+    myTree->Branch("SVfit_phiMETDown", &_SVphiMETDown);
+    myTree->Branch("SVfit_etaUncMETUp", &_SVetaUncMETUp);
+    myTree->Branch("SVfit_etaUncMETDown", &_SVetaUncMETDown);
+    myTree->Branch("SVfit_etaMETUp", &_SVetaMETUp);
+    myTree->Branch("SVfit_etaMETDown", &_SVetaMETDown);
+    myTree->Branch("SVfit_ptUncMETUp", &_SVptUncMETUp);
+    myTree->Branch("SVfit_ptUncMETDown", &_SVptUncMETDown);
+    myTree->Branch("SVfit_ptMETUp", &_SVptMETUp);
+    myTree->Branch("SVfit_ptMETDown", &_SVptMETDown);
+    myTree->Branch("SVfitTransverseMassUncMETUp",&_SVmassTransverseUncMETUp);
+    myTree->Branch("SVfitTransverseMassUncMETDown",&_SVmassTransverseUncMETDown);
+    myTree->Branch("SVfitTransverseMassMETUp",&_SVmassTransverseMETUp);
+    myTree->Branch("SVfitTransverseMassMETDown",&_SVmassTransverseMETDown);
+    myTree->Branch("SVfitMassUncMETUp",&_SVmassUncMETUp);
+    myTree->Branch("SVfitMassUncMETDown",&_SVmassUncMETDown);
     myTree->Branch("SVfitMassMETUp",&_SVmassMETUp);
     myTree->Branch("SVfitMassMETDown",&_SVmassMETDown);
+
+    myTree->Branch("SVfit_fitMETPhiEleUp", &_SVMetPhiEleUp);
+    myTree->Branch("SVfit_fitMETPhiEleDown", &_SVMetPhiEleDown);
+    myTree->Branch("SVfit_fitMETRhoEleUp", &_SVMetRhoEleUp);
+    myTree->Branch("SVfit_fitMETRhoEleDown", &_SVMetRhoEleDown);
+    myTree->Branch("SVfit_phiUncEleUp", &_SVphiUncEleUp);
+    myTree->Branch("SVfit_phiUncEleDown", &_SVphiUncEleDown);
+    myTree->Branch("SVfit_phiEleUp", &_SVphiEleUp);
+    myTree->Branch("SVfit_phiEleDown", &_SVphiEleDown);
+    myTree->Branch("SVfit_etaUncEleUp", &_SVetaUncEleUp);
+    myTree->Branch("SVfit_etaUncEleDown", &_SVetaUncEleDown);
+    myTree->Branch("SVfit_etaEleUp", &_SVetaEleUp);
+    myTree->Branch("SVfit_etaEleDown", &_SVetaEleDown);
+    myTree->Branch("SVfit_ptUncEleUp", &_SVptUncEleUp);
+    myTree->Branch("SVfit_ptUncEleDown", &_SVptUncEleDown);
+    myTree->Branch("SVfit_ptEleUp", &_SVptEleUp);
+    myTree->Branch("SVfit_ptEleDown", &_SVptEleDown);
+    myTree->Branch("SVfitTransverseMassUncEleUp",&_SVmassTransverseUncEleUp);
+    myTree->Branch("SVfitTransverseMassUncEleDown",&_SVmassTransverseUncEleDown);
+    myTree->Branch("SVfitTransverseMassEleUp",&_SVmassTransverseEleUp);
+    myTree->Branch("SVfitTransverseMassEleDown",&_SVmassTransverseEleDown);
+    myTree->Branch("SVfitMassUncEleUp",&_SVmassUncEleUp);
+    myTree->Branch("SVfitMassUncEleDown",&_SVmassUncEleDown);
+    myTree->Branch("SVfitMassEleUp",&_SVmassEleUp);
+    myTree->Branch("SVfitMassEleDown",&_SVmassEleDown);
   }// end if isMC
   //myTree->Branch("daughters2",&_daughter2);
 
@@ -2564,82 +2638,108 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
     float thisMETpx_uncorr = ( cand.hasUserFloat("uncorrMEt_px") ) ? cand.userFloat("uncorrMEt_px") : -999.;
     float thisMETpy_uncorr = ( cand.hasUserFloat("uncorrMEt_py") ) ? cand.userFloat("uncorrMEt_py") : -999.;
     
-    bool hasUp   = cand.hasUserFloat ("SVfitMassTauUp");
-    bool hasDown = cand.hasUserFloat ("SVfitMassTauDown");
+    bool hasTESUp   = cand.hasUserFloat ("SVfitMassTauUp");
+    bool hasTESDown = cand.hasUserFloat ("SVfitMassTauDown");
     bool hasMETUp   = cand.hasUserFloat ("SVfitMassMETUp");
     bool hasMETDown = cand.hasUserFloat ("SVfitMassMETDown");
+    bool hasEESUp   = cand.hasUserFloat ("SVfitMassEleUp");
+    bool hasEESDown = cand.hasUserFloat ("SVfitMassEleDown");
 
     _SVmass.push_back(cand.userFloat("SVfitMass"));
-    _SVmassTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfitMassTauUp")   : -999. ));
-    _SVmassTauDown.push_back( (hasDown ? cand.userFloat("SVfitMassTauDown") : -999. ));
+    _SVmassTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfitMassTauUp")   : -999. ));
+    _SVmassTauDown.push_back( (hasTESDown ? cand.userFloat("SVfitMassTauDown") : -999. ));
     _SVmassMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfitMassMETUp")   : -999. ));
     _SVmassMETDown.push_back( (hasMETDown ? cand.userFloat("SVfitMassMETDown") : -999. ));
+    _SVmassEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfitMassEleUp")   : -999. ));
+    _SVmassEleDown.push_back( (hasEESDown ? cand.userFloat("SVfitMassEleDown") : -999. ));
 
     _SVmassUnc.push_back(cand.userFloat("SVfitMassUnc"));
-    _SVmassUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfitMassUncTauUp")   : -999. ));
-    _SVmassUncTauDown.push_back( (hasDown ? cand.userFloat("SVfitMassUncTauDown") : -999. ));
+    _SVmassUncTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfitMassUncTauUp")   : -999. ));
+    _SVmassUncTauDown.push_back( (hasTESDown ? cand.userFloat("SVfitMassUncTauDown") : -999. ));
     _SVmassUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfitMassUncMETUp")   : -999. ));
     _SVmassUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfitMassUncMETDown") : -999. ));
+    _SVmassUncEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfitMassUncEleUp")   : -999. ));
+    _SVmassUncEleDown.push_back( (hasEESDown ? cand.userFloat("SVfitMassUncEleDown") : -999. ));
 
     _SVmassTransverse.push_back(cand.userFloat("SVfitTransverseMass"));
-    _SVmassTransverseTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfitTransverseMassTauUp")  : -999. ));
-    _SVmassTransverseTauDown.push_back( (hasDown ? cand.userFloat("SVfitTransverseMassTauDown"): -999. ));
+    _SVmassTransverseTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfitTransverseMassTauUp")  : -999. ));
+    _SVmassTransverseTauDown.push_back( (hasTESDown ? cand.userFloat("SVfitTransverseMassTauDown"): -999. ));
     _SVmassTransverseMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfitTransverseMassMETUp")  : -999. ));
     _SVmassTransverseMETDown.push_back( (hasMETDown ? cand.userFloat("SVfitTransverseMassMETDown"): -999. ));
+    _SVmassTransverseEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfitTransverseMassEleUp")  : -999. ));
+    _SVmassTransverseEleDown.push_back( (hasEESDown ? cand.userFloat("SVfitTransverseMassEleDown"): -999. ));
 
     _SVmassTransverseUnc.push_back(cand.userFloat("SVfitTransverseMassUnc"));
-    _SVmassTransverseUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfitTransverseMassUncTauUp")  : -999. ));
-    _SVmassTransverseUncTauDown.push_back( (hasDown ? cand.userFloat("SVfitTransverseMassUncTauDown"): -999. ));
+    _SVmassTransverseUncTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfitTransverseMassUncTauUp")  : -999. ));
+    _SVmassTransverseUncTauDown.push_back( (hasTESDown ? cand.userFloat("SVfitTransverseMassUncTauDown"): -999. ));
     _SVmassTransverseUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfitTransverseMassUncMETUp")  : -999. ));
     _SVmassTransverseUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfitTransverseMassUncMETDown"): -999. ));
+    _SVmassTransverseUncEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfitTransverseMassUncEleUp")  : -999. ));
+    _SVmassTransverseUncEleDown.push_back( (hasEESDown ? cand.userFloat("SVfitTransverseMassUncEleDown"): -999. ));
 
     _SVpt.push_back(cand.userFloat("SVfit_pt"));
-    _SVptTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_ptTauUp")  : -999. ));
-    _SVptTauDown.push_back( (hasDown ? cand.userFloat("SVfit_ptTauDown"): -999. ));
+    _SVptTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfit_ptTauUp")  : -999. ));
+    _SVptTauDown.push_back( (hasTESDown ? cand.userFloat("SVfit_ptTauDown"): -999. ));
     _SVptMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_ptMETUp")  : -999. ));
     _SVptMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_ptMETDown"): -999. ));
+    _SVptEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfit_ptEleUp")  : -999. ));
+    _SVptEleDown.push_back( (hasEESDown ? cand.userFloat("SVfit_ptEleDown"): -999. ));
 
     _SVptUnc.push_back(cand.userFloat("SVfit_ptUnc"));
-    _SVptUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_ptUncTauUp")  : -999. ));
-    _SVptUncTauDown.push_back( (hasDown ? cand.userFloat("SVfit_ptUncTauDown"): -999. ));
+    _SVptUncTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfit_ptUncTauUp")  : -999. ));
+    _SVptUncTauDown.push_back( (hasTESDown ? cand.userFloat("SVfit_ptUncTauDown"): -999. ));
     _SVptUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_ptUncMETUp")  : -999. ));
     _SVptUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_ptUncMETDown"): -999. ));
+    _SVptUncEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfit_ptUncEleUp")  : -999. ));
+    _SVptUncEleDown.push_back( (hasEESDown ? cand.userFloat("SVfit_ptUncEleDown"): -999. ));
 
     _SVeta.push_back(cand.userFloat("SVfit_eta"));
-    _SVetaTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_etaTauUp")  : -999. ));
-    _SVetaTauDown.push_back( (hasDown ? cand.userFloat("SVfit_etaTauDown"): -999. ));
+    _SVetaTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfit_etaTauUp")  : -999. ));
+    _SVetaTauDown.push_back( (hasTESDown ? cand.userFloat("SVfit_etaTauDown"): -999. ));
     _SVetaMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_etaMETUp")  : -999. ));
     _SVetaMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_etaMETDown"): -999. ));
+    _SVetaEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfit_etaEleUp")  : -999. ));
+    _SVetaEleDown.push_back( (hasEESDown ? cand.userFloat("SVfit_etaEleDown"): -999. ));
 
     _SVetaUnc.push_back(cand.userFloat("SVfit_etaUnc"));
-    _SVetaUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_etaUncTauUp")  : -999. ));
-    _SVetaUncTauDown.push_back( (hasDown ? cand.userFloat("SVfit_etaUncTauDown"): -999. ));
+    _SVetaUncTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfit_etaUncTauUp")  : -999. ));
+    _SVetaUncTauDown.push_back( (hasTESDown ? cand.userFloat("SVfit_etaUncTauDown"): -999. ));
     _SVetaUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_etaUncMETUp")  : -999. ));
     _SVetaUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_etaUncMETDown"): -999. ));
+    _SVetaUncEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfit_etaUncEleUp")  : -999. ));
+    _SVetaUncEleDown.push_back( (hasEESDown ? cand.userFloat("SVfit_etaUncEleDown"): -999. ));
 
     _SVphi.push_back(cand.userFloat("SVfit_phi"));
-    _SVphiTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_phiTauUp")  : -999. ));
-    _SVphiTauDown.push_back( (hasDown ? cand.userFloat("SVfit_phiTauDown"): -999. ));
+    _SVphiTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfit_phiTauUp")  : -999. ));
+    _SVphiTauDown.push_back( (hasTESDown ? cand.userFloat("SVfit_phiTauDown"): -999. ));
     _SVphiMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_phiMETUp")  : -999. ));
     _SVphiMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_phiMETDown"): -999. ));
+    _SVphiEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfit_phiEleUp")  : -999. ));
+    _SVphiEleDown.push_back( (hasEESDown ? cand.userFloat("SVfit_phiEleDown"): -999. ));
 
     _SVphiUnc.push_back(cand.userFloat("SVfit_phiUnc"));
-    _SVphiUncTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_phiUncTauUp")  : -999. ));
-    _SVphiUncTauDown.push_back( (hasDown ? cand.userFloat("SVfit_phiUncTauDown"): -999. ));
+    _SVphiUncTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfit_phiUncTauUp")  : -999. ));
+    _SVphiUncTauDown.push_back( (hasTESDown ? cand.userFloat("SVfit_phiUncTauDown"): -999. ));
     _SVphiUncMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_phiUncMETUp")  : -999. ));
     _SVphiUncMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_phiUncMETDown"): -999. ));
+    _SVphiUncEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfit_phiUncEleUp")  : -999. ));
+    _SVphiUncEleDown.push_back( (hasEESDown ? cand.userFloat("SVfit_phiUncEleDown"): -999. ));
 
     _SVMetRho.push_back(cand.userFloat("SVfit_METRho"));
-    _SVMetRhoTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_METRhoTauUp")  : -999. ));
-    _SVMetRhoTauDown.push_back( (hasDown ? cand.userFloat("SVfit_METRhoTauDown"): -999. ));
+    _SVMetRhoTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfit_METRhoTauUp")  : -999. ));
+    _SVMetRhoTauDown.push_back( (hasTESDown ? cand.userFloat("SVfit_METRhoTauDown"): -999. ));
     _SVMetRhoMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_METRhoMETUp")  : -999. ));
     _SVMetRhoMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_METRhoMETDown"): -999. ));
+    _SVMetRhoEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfit_METRhoEleUp")  : -999. ));
+    _SVMetRhoEleDown.push_back( (hasEESDown ? cand.userFloat("SVfit_METRhoEleDown"): -999. ));
 
     _SVMetPhi.push_back(cand.userFloat("SVfit_METPhi"));
-    _SVMetPhiTauUp.push_back  ( (hasUp   ? cand.userFloat("SVfit_METPhiTauUp")  : -999. ));
-    _SVMetPhiTauDown.push_back( (hasDown ? cand.userFloat("SVfit_METPhiTauDown"): -999. ));
+    _SVMetPhiTauUp.push_back  ( (hasTESUp   ? cand.userFloat("SVfit_METPhiTauUp")  : -999. ));
+    _SVMetPhiTauDown.push_back( (hasTESDown ? cand.userFloat("SVfit_METPhiTauDown"): -999. ));
     _SVMetPhiMETUp.push_back  ( (hasMETUp   ? cand.userFloat("SVfit_METPhiMETUp")  : -999. ));
     _SVMetPhiMETDown.push_back( (hasMETDown ? cand.userFloat("SVfit_METPhiMETDown"): -999. ));
+    _SVMetPhiEleUp.push_back  ( (hasEESUp   ? cand.userFloat("SVfit_METPhiEleUp")  : -999. ));
+    _SVMetPhiEleDown.push_back( (hasEESDown ? cand.userFloat("SVfit_METPhiEleDown"): -999. ));
 
     _metx.push_back(thisMETpx);
     _mety.push_back(thisMETpy);

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -335,16 +335,24 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   std::vector<Float_t> _daughters_neutral_pz;
   std::vector<Float_t> _daughters_neutral_e;
 
-  std::vector<Int_t> _daughters_TauUpExists;
+  std::vector<Int_t> _daughters_hasTES;
   std::vector<Float_t> _daughters_px_TauUp;
   std::vector<Float_t> _daughters_py_TauUp;
   std::vector<Float_t> _daughters_pz_TauUp;
   std::vector<Float_t> _daughters_e_TauUp;
-  std::vector<Int_t> _daughters_TauDownExists;
   std::vector<Float_t> _daughters_px_TauDown;
   std::vector<Float_t> _daughters_py_TauDown;
   std::vector<Float_t> _daughters_pz_TauDown;
   std::vector<Float_t> _daughters_e_TauDown;
+  std::vector<Int_t> _daughters_hasEES;
+  std::vector<Float_t> _daughters_px_EleUp;
+  std::vector<Float_t> _daughters_py_EleUp;
+  std::vector<Float_t> _daughters_pz_EleUp;
+  std::vector<Float_t> _daughters_e_EleUp;
+  std::vector<Float_t> _daughters_px_EleDown;
+  std::vector<Float_t> _daughters_py_EleDown;
+  std::vector<Float_t> _daughters_pz_EleDown;
+  std::vector<Float_t> _daughters_e_EleDown;
   std::vector<Int_t> _daughters_genindex;
   std::vector<Int_t> _daughters_charge;
   std::vector<Int_t> _daughters_isTauMatched;
@@ -489,14 +497,18 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
 
   std::vector<Float_t> _metx;
   std::vector<Float_t> _mety;
-  std::vector<Float_t> _metx_up;
-  std::vector<Float_t> _mety_up;
-  std::vector<Float_t> _metx_down;
-  std::vector<Float_t> _mety_down;
+  std::vector<Float_t> _metx_up_jes;
+  std::vector<Float_t> _mety_up_jes;
+  std::vector<Float_t> _metx_down_jes;
+  std::vector<Float_t> _mety_down_jes;
   std::vector<Float_t> _metx_up_tes;
   std::vector<Float_t> _mety_up_tes;
   std::vector<Float_t> _metx_down_tes;
   std::vector<Float_t> _mety_down_tes;
+  std::vector<Float_t> _metx_up_ees;
+  std::vector<Float_t> _mety_up_ees;
+  std::vector<Float_t> _metx_down_ees;
+  std::vector<Float_t> _mety_down_ees;
   std::vector<Float_t> _uncorrmetx;
   std::vector<Float_t> _uncorrmety;
   std::vector<Float_t> _metCov00;
@@ -1077,16 +1089,24 @@ void HTauTauNtuplizer::Initialize(){
   _daughters_neutral_pz.clear();
   _daughters_neutral_e.clear();
    
-  _daughters_TauUpExists.clear();
+  _daughters_hasTES.clear();
   _daughters_px_TauUp.clear();
   _daughters_py_TauUp.clear();
   _daughters_pz_TauUp.clear();
   _daughters_e_TauUp.clear();
-  _daughters_TauDownExists.clear();
   _daughters_px_TauDown.clear();
   _daughters_py_TauDown.clear();
   _daughters_pz_TauDown.clear();
   _daughters_e_TauDown.clear();
+  _daughters_hasEES.clear();
+  _daughters_px_EleUp.clear();
+  _daughters_py_EleUp.clear();
+  _daughters_pz_EleUp.clear();
+  _daughters_e_EleUp.clear();
+  _daughters_px_EleDown.clear();
+  _daughters_py_EleDown.clear();
+  _daughters_pz_EleDown.clear();
+  _daughters_e_EleDown.clear();
   _daughters_charge.clear();
   _daughters_isTauMatched.clear();
   _daughters_genindex.clear();
@@ -1308,14 +1328,18 @@ void HTauTauNtuplizer::Initialize(){
   _daughters_highestEt_L1IsoTauMatched.clear();
   _metx.clear();
   _mety.clear();
-  _metx_up.clear();
-  _mety_up.clear();
-  _metx_down.clear();
-  _mety_down.clear();
+  _metx_up_jes.clear();
+  _mety_up_jes.clear();
+  _metx_down_jes.clear();
+  _mety_down_jes.clear();
   _metx_up_tes.clear();
   _mety_up_tes.clear();
   _metx_down_tes.clear();
   _mety_down_tes.clear();
+  _metx_up_ees.clear();
+  _mety_up_ees.clear();
+  _metx_down_ees.clear();
+  _mety_down_ees.clear();
   _uncorrmetx.clear();
   _uncorrmety.clear();
   _metCov00.clear();
@@ -1634,18 +1658,27 @@ void HTauTauNtuplizer::beginJob(){
 
      myTree->Branch("daughters_highestEt_L1IsoTauMatched", &_daughters_highestEt_L1IsoTauMatched);
      if(theisMC){ 
-     myTree->Branch("daughters_TauUpExists",&_daughters_TauUpExists);
+     myTree->Branch("daughters_hasTES",&_daughters_hasTES);
       myTree->Branch("daughters_px_TauUp",&_daughters_px_TauUp);
       myTree->Branch("daughters_py_TauUp",&_daughters_py_TauUp);
       myTree->Branch("daughters_pz_TauUp",&_daughters_pz_TauUp);
       myTree->Branch("daughters_e_TauUp",&_daughters_e_TauUp);
-      myTree->Branch("daughters_isTauMatched",&_daughters_isTauMatched);
-
-      myTree->Branch("daughters_TauDownExists",&_daughters_TauDownExists);
       myTree->Branch("daughters_px_TauDown",&_daughters_px_TauDown);
       myTree->Branch("daughters_py_TauDown",&_daughters_py_TauDown);
       myTree->Branch("daughters_pz_TauDown",&_daughters_pz_TauDown);
       myTree->Branch("daughters_e_TauDown",&_daughters_e_TauDown);
+     myTree->Branch("daughters_hasEES",&_daughters_hasEES);
+      myTree->Branch("daughters_px_EleUp",&_daughters_px_EleUp);
+      myTree->Branch("daughters_py_EleUp",&_daughters_py_EleUp);
+      myTree->Branch("daughters_pz_EleUp",&_daughters_pz_EleUp);
+      myTree->Branch("daughters_e_EleUp",&_daughters_e_EleUp);
+      myTree->Branch("daughters_px_EleDown",&_daughters_px_EleDown);
+      myTree->Branch("daughters_py_EleDown",&_daughters_py_EleDown);
+      myTree->Branch("daughters_pz_EleDown",&_daughters_pz_EleDown);
+      myTree->Branch("daughters_e_EleDown",&_daughters_e_EleDown);
+
+      myTree->Branch("daughters_isTauMatched",&_daughters_isTauMatched);
+
     //myTree->Branch("genDaughters",&_genDaughters);
     //myTree->Branch("quarks_px",&_bquarks_px);
     //myTree->Branch("quarks_py",&_bquarks_py);
@@ -1770,14 +1803,18 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("isOSCand",&_isOSCand);
   myTree->Branch("METx",&_metx);
   myTree->Branch("METy",&_mety);
-  myTree->Branch("METx_UP",&_metx_up);
-  myTree->Branch("METy_UP",&_mety_up);
-  myTree->Branch("METx_DOWN",&_metx_down);
-  myTree->Branch("METy_DOWN",&_mety_down);
+  myTree->Branch("METx_UP_JES",&_metx_up_jes);
+  myTree->Branch("METy_UP_JES",&_mety_up_jes);
+  myTree->Branch("METx_DOWN_JES",&_metx_down_jes);
+  myTree->Branch("METy_DOWN_JES",&_mety_down_jes);
   myTree->Branch("METx_UP_TES",&_metx_up_tes);
   myTree->Branch("METy_UP_TES",&_mety_up_tes);
   myTree->Branch("METx_DOWN_TES",&_metx_down_tes);
   myTree->Branch("METy_DOWN_TES",&_mety_down_tes);
+  myTree->Branch("METx_UP_EES",&_metx_up_ees);
+  myTree->Branch("METy_UP_EES",&_mety_up_ees);
+  myTree->Branch("METx_DOWN_EES",&_metx_down_ees);
+  myTree->Branch("METy_DOWN_EES",&_mety_down_ees);
   myTree->Branch("uncorrMETx",&_uncorrmetx);
   myTree->Branch("uncorrMETy",&_uncorrmety);
   myTree->Branch("MET_cov00",&_metCov00);
@@ -2512,14 +2549,18 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
 
     float thisMETpx = cand.userFloat("MEt_px");
     float thisMETpy = cand.userFloat("MEt_py");
-    float thisMETpx_up = cand.userFloat("MEt_px_UP");
-    float thisMETpy_up = cand.userFloat("MEt_py_UP");
-    float thisMETpx_down = cand.userFloat("MEt_px_DOWN");
-    float thisMETpy_down = cand.userFloat("MEt_py_DOWN");
+    float thisMETpx_up_jes = cand.userFloat("MEt_px_UP_JES");
+    float thisMETpy_up_jes = cand.userFloat("MEt_py_UP_JES");
+    float thisMETpx_down_jes = cand.userFloat("MEt_px_DOWN_JES");
+    float thisMETpy_down_jes = cand.userFloat("MEt_py_DOWN_JES");
     float thisMETpx_up_tes = cand.userFloat("MEt_px_UP_TES");
     float thisMETpy_up_tes = cand.userFloat("MEt_py_UP_TES");
     float thisMETpx_down_tes = cand.userFloat("MEt_px_DOWN_TES");
     float thisMETpy_down_tes = cand.userFloat("MEt_py_DOWN_TES");
+    float thisMETpx_up_ees = cand.userFloat("MEt_px_UP_EES");
+    float thisMETpy_up_ees = cand.userFloat("MEt_py_UP_EES");
+    float thisMETpx_down_ees = cand.userFloat("MEt_px_DOWN_EES");
+    float thisMETpy_down_ees = cand.userFloat("MEt_py_DOWN_EES");
     float thisMETpx_uncorr = ( cand.hasUserFloat("uncorrMEt_px") ) ? cand.userFloat("uncorrMEt_px") : -999.;
     float thisMETpy_uncorr = ( cand.hasUserFloat("uncorrMEt_py") ) ? cand.userFloat("uncorrMEt_py") : -999.;
     
@@ -2602,14 +2643,18 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
 
     _metx.push_back(thisMETpx);
     _mety.push_back(thisMETpy);
-    _metx_up.push_back(thisMETpx_up);
-    _mety_up.push_back(thisMETpy_up);
-    _metx_down.push_back(thisMETpx_down);
-    _mety_down.push_back(thisMETpy_down);
+    _metx_up_jes.push_back(thisMETpx_up_jes);
+    _mety_up_jes.push_back(thisMETpy_up_jes);
+    _metx_down_jes.push_back(thisMETpx_down_jes);
+    _mety_down_jes.push_back(thisMETpy_down_jes);
     _metx_up_tes.push_back(thisMETpx_up_tes);
     _mety_up_tes.push_back(thisMETpy_up_tes);
     _metx_down_tes.push_back(thisMETpx_down_tes);
     _mety_down_tes.push_back(thisMETpy_down_tes);
+    _metx_up_ees.push_back(thisMETpx_up_ees);
+    _mety_up_ees.push_back(thisMETpy_up_ees);
+    _metx_down_ees.push_back(thisMETpx_down_ees);
+    _mety_down_ees.push_back(thisMETpy_down_ees);
     _uncorrmetx.push_back(thisMETpx_uncorr);
     _uncorrmety.push_back(thisMETpy_uncorr);
     _metCov00.push_back(cand.userFloat("MEt_cov00"));
@@ -3267,30 +3312,35 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     
     TLorentzVector pfourTauUp;
     TLorentzVector pfourTauDown;
+    TLorentzVector pfourEleUp;
+    TLorentzVector pfourEleDown;
 
-    bool existUp   = userdatahelpers::hasUserInt(cand,"TauUpExists"); // simply to check if the userfloat exists, i.e. if it is a tau
-    bool existDown = userdatahelpers::hasUserInt(cand,"TauDownExists"); // simply to check if the userfloat exists, i.e. if it is a tau
+    bool existTESshift = userdatahelpers::hasUserInt(cand,"isTESShifted"); // simply to check if the userfloat exists
+    bool existEESshift = userdatahelpers::hasUserInt(cand,"isEESShifted"); // simply to check if the userfloat exists
     bool isTauMatched = userdatahelpers::hasUserInt(cand,"isTauMatched"); // check if it is a tau
-
-    int hasUp   = ( existUp   ? userdatahelpers::getUserInt(cand,"TauUpExists")   : false) ;   // actual check of the value of the userfloat
-    int hasDown = ( existDown ? userdatahelpers::getUserInt(cand,"TauDownExists") : false) ; // actual check of the value of the userfloat
-   
     
-    if(hasUp)
+    int (hasTES) = ( existTESshift ? userdatahelpers::getUserInt(cand,"isTESShifted") : false) ;   // actual check of the value of the userfloat
+    int (hasEES) = ( existEESshift ? userdatahelpers::getUserInt(cand,"isEESShifted") : false) ;   // actual check of the value of the userfloat
+
+    if(hasTES)
     {
       pfourTauUp.SetPxPyPzE(userdatahelpers::getUserFloat(cand,"px_TauUp"),userdatahelpers::getUserFloat(cand,"py_TauUp"),userdatahelpers::getUserFloat(cand,"pz_TauUp"),userdatahelpers::getUserFloat(cand,"e_TauUp"));
-    }
-    else
-    {
-      pfourTauUp.SetPxPyPzE(-999.,-999.,-999.,-999.);
-    }
-    if(hasDown)
-    {
       pfourTauDown.SetPxPyPzE(userdatahelpers::getUserFloat(cand,"px_TauDown"),userdatahelpers::getUserFloat(cand,"py_TauDown"),userdatahelpers::getUserFloat(cand,"pz_TauDown"),userdatahelpers::getUserFloat(cand,"e_TauDown"));
     }
     else
     {
+      pfourTauUp.SetPxPyPzE(-999.,-999.,-999.,-999.);
       pfourTauDown.SetPxPyPzE(-999.,-999.,-999.,-999.);
+    }
+    if(hasEES)
+    {
+      pfourEleUp.SetPxPyPzE(userdatahelpers::getUserFloat(cand,"px_EleUp"),userdatahelpers::getUserFloat(cand,"py_EleUp"),userdatahelpers::getUserFloat(cand,"pz_EleUp"),userdatahelpers::getUserFloat(cand,"e_EleUp"));
+      pfourEleDown.SetPxPyPzE(userdatahelpers::getUserFloat(cand,"px_EleDown"),userdatahelpers::getUserFloat(cand,"py_EleDown"),userdatahelpers::getUserFloat(cand,"pz_EleDown"),userdatahelpers::getUserFloat(cand,"e_EleDown"));
+    }
+    else
+    {
+      pfourEleUp.SetPxPyPzE(-999.,-999.,-999.,-999.);
+      pfourEleDown.SetPxPyPzE(-999.,-999.,-999.,-999.);
     }
     
     if(theFSR){
@@ -3318,19 +3368,27 @@ void HTauTauNtuplizer::FillSoftLeptons(const edm::View<reco::Candidate> *daus,
     _daughters_pz.push_back( (float) pfour.Z());
     _daughters_e.push_back( (float) pfour.T());
 
-    _daughters_TauUpExists.push_back( (existUp ? hasUp : 0) );
+    _daughters_hasTES.push_back( (hasTES ? 1 : 0) );
     _daughters_px_TauUp.push_back((float)pfourTauUp.Px());
     _daughters_py_TauUp.push_back((float)pfourTauUp.Py());
     _daughters_pz_TauUp.push_back((float)pfourTauUp.Pz());
     _daughters_e_TauUp.push_back((float)pfourTauUp.E());
-
-    _daughters_TauDownExists.push_back( (existDown ? hasDown : 0) );
     _daughters_px_TauDown.push_back((float)pfourTauDown.Px());
     _daughters_py_TauDown.push_back((float)pfourTauDown.Py());
     _daughters_pz_TauDown.push_back((float)pfourTauDown.Pz());
     _daughters_e_TauDown.push_back((float)pfourTauDown.E());
 
-    _daughters_isTauMatched.push_back( (isTauMatched ? hasUp : 0) );
+    _daughters_hasEES.push_back( (hasEES ? 1 : 0) );
+    _daughters_px_EleUp.push_back((float)pfourEleUp.Px());
+    _daughters_py_EleUp.push_back((float)pfourEleUp.Py());
+    _daughters_pz_EleUp.push_back((float)pfourEleUp.Pz());
+    _daughters_e_EleUp.push_back((float)pfourEleUp.E());
+    _daughters_px_EleDown.push_back((float)pfourEleDown.Px());
+    _daughters_py_EleDown.push_back((float)pfourEleDown.Py());
+    _daughters_pz_EleDown.push_back((float)pfourEleDown.Pz());
+    _daughters_e_EleDown.push_back((float)pfourEleDown.E());
+
+    _daughters_isTauMatched.push_back( (isTauMatched ? 1 : 0) );
 
     // gen info
     

--- a/NtupleProducer/plugins/ShiftMETforEES.cc
+++ b/NtupleProducer/plugins/ShiftMETforEES.cc
@@ -1,9 +1,9 @@
 /*
-** class  : ShiftMETforTES
+** class  : ShiftMETforEES
 ** author : F. Brivio (MIB)
-** date   : 20 June 2018
-** brief  : takes pat::MET and taus in input and produces 4 doubles for the shifts of the MET due to TES:
-**          MET_dx_UP, MET_dy_UP, MET_dx_DOWN, MET_dy_DOWN
+** date   : 19 December 2019
+** brief  : takes pat::MET and taus in input and produces 4 doubles for the shifts of the MET due to Ele->tau ES:
+**          METdxUP_EES, METdyUP_EES, METdxDOWN_EES, METdyDOWN_EES
 */
 
 #include <FWCore/Framework/interface/Frameworkfwd.h>
@@ -31,12 +31,12 @@ using namespace reco;
 
 using LorentzVectorE = ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double>>;
 
-class ShiftMETforTES : public edm::EDProducer {
+class ShiftMETforEES : public edm::EDProducer {
     public: 
         /// Constructor
-        explicit ShiftMETforTES(const edm::ParameterSet&);
+        explicit ShiftMETforEES(const edm::ParameterSet&);
         /// Destructor
-        ShiftMETforTES(){};
+        ShiftMETforEES(){};
 
     private:
         virtual void beginJob(){};  
@@ -47,18 +47,18 @@ class ShiftMETforTES : public edm::EDProducer {
         edm::EDGetTokenT<pat::TauCollection> theTauTag;
 };
 
-ShiftMETforTES::ShiftMETforTES(const edm::ParameterSet& iConfig) :
+ShiftMETforEES::ShiftMETforEES(const edm::ParameterSet& iConfig) :
 theMETTag(consumes<View<pat::MET>>(iConfig.getParameter<edm::InputTag>("srcMET"))),
 theTauTag(consumes<pat::TauCollection>(iConfig.getParameter<edm::InputTag>("tauCollection")))
 {
-    produces<double>("METdxUP");
-    produces<double>("METdyUP");
-    produces<double>("METdxDOWN");
-    produces<double>("METdyDOWN");
+    produces<double>("METdxUP_EES");
+    produces<double>("METdyUP_EES");
+    produces<double>("METdxDOWN_EES");
+    produces<double>("METdyDOWN_EES");
     
 }
 
-void ShiftMETforTES::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+void ShiftMETforEES::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
     // Declare ptrs to save MET variations
     std::unique_ptr<double> dx_UP_ptr   (new double);
@@ -103,19 +103,19 @@ void ShiftMETforTES::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       pfour.SetPxPyPzE (l->px(), l->py(), l->pz(), l->energy());
       
       // Shifted taus
-      TLorentzVector pfourTauUp;
-      TLorentzVector pfourTauDown;
+      TLorentzVector pfourEleUp;
+      TLorentzVector pfourEleDown;
 
-      bool existTESshift = userdatahelpers::hasUserInt(l,"isTESShifted"); // simply to check if the userfloat exists
-      int hasTES = ( existTESshift ? userdatahelpers::getUserInt(l,"isTESShifted") : false) ;   // actual check of the value of the userfloat
+      bool existEESshift = userdatahelpers::hasUserInt(l,"isEESShifted"); // simply to check if the userfloat exists
+      int hasEES = ( existEESshift ? userdatahelpers::getUserInt(l,"isEESShifted") : false) ;   // actual check of the value of the userfloat
       //cout << "---> exist/user/has: " << existUp << " / " << userdatahelpers::getUserInt(l,"TauUpExists") << " / " << hasUp << endl;
-      if(hasTES)
+      if(hasEES)
       {
-        pfourTauUp.SetPxPyPzE ( userdatahelpers::getUserFloat(l,"px_TauUp"), userdatahelpers::getUserFloat(l,"py_TauUp"), userdatahelpers::getUserFloat(l,"pz_TauUp"), userdatahelpers::getUserFloat(l,"e_TauUp"));
-        deltaTaus_UP += ( pfourTauUp - pfour );
+        pfourEleUp.SetPxPyPzE ( userdatahelpers::getUserFloat(l,"px_EleUp"), userdatahelpers::getUserFloat(l,"py_EleUp"), userdatahelpers::getUserFloat(l,"pz_EleUp"), userdatahelpers::getUserFloat(l,"e_EleUp"));
+        deltaTaus_UP += ( pfourEleUp - pfour );
 
-        pfourTauDown.SetPxPyPzE ( userdatahelpers::getUserFloat(l,"px_TauDown"), userdatahelpers::getUserFloat(l,"py_TauDown"), userdatahelpers::getUserFloat(l,"pz_TauDown"), userdatahelpers::getUserFloat(l,"e_TauDown"));
-        deltaTaus_DOWN += ( pfourTauDown - pfour );
+        pfourEleDown.SetPxPyPzE ( userdatahelpers::getUserFloat(l,"px_EleDown"), userdatahelpers::getUserFloat(l,"py_EleDown"), userdatahelpers::getUserFloat(l,"pz_EleDown"), userdatahelpers::getUserFloat(l,"e_EleDown"));
+        deltaTaus_DOWN += ( pfourEleDown - pfour );
 
         //cout << "---> deltaTaus_MID: " << deltaTaus_UP.Px() << " / " << deltaTaus_UP.Py() << endl;
         //cout << "---> pfour       : " << pfour.Px() << " / " << pfour.Py() << endl;
@@ -143,12 +143,12 @@ void ShiftMETforTES::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     //cout << "SHIFTED UP  : " << *dx_UP_ptr << " / " << *dy_UP_ptr << endl;
     //cout << "SHIFTED DOWN: " << *dx_DOWN_ptr << " / " << *dy_DOWN_ptr << endl;
 
-    iEvent.put( std::move(dx_UP_ptr)  , "METdxUP"   );
-    iEvent.put( std::move(dy_UP_ptr)  , "METdyUP"   );
-    iEvent.put( std::move(dx_DOWN_ptr), "METdxDOWN" );
-    iEvent.put( std::move(dy_DOWN_ptr), "METdyDOWN" );
+    iEvent.put( std::move(dx_UP_ptr)  , "METdxUP_EES"   );
+    iEvent.put( std::move(dy_UP_ptr)  , "METdyUP_EES"   );
+    iEvent.put( std::move(dx_DOWN_ptr), "METdxDOWN_EES" );
+    iEvent.put( std::move(dy_DOWN_ptr), "METdyDOWN_EES" );
     
 }
 
 #include <FWCore/Framework/interface/MakerMacros.h>
-DEFINE_FWK_MODULE(ShiftMETforTES);
+DEFINE_FWK_MODULE(ShiftMETforEES);

--- a/NtupleProducer/plugins/ShiftMETforEES.cc
+++ b/NtupleProducer/plugins/ShiftMETforEES.cc
@@ -3,7 +3,7 @@
 ** author : F. Brivio (MIB)
 ** date   : 19 December 2019
 ** brief  : takes pat::MET and taus in input and produces 4 doubles for the shifts of the MET due to Ele->tau ES:
-**          METdxUP_EES, METdyUP_EES, METdxDOWN_EES, METdyDOWN_EES
+**          METdxUPEES, METdyUPEES, METdxDOWNEES, METdyDOWNEES
 */
 
 #include <FWCore/Framework/interface/Frameworkfwd.h>
@@ -51,10 +51,10 @@ ShiftMETforEES::ShiftMETforEES(const edm::ParameterSet& iConfig) :
 theMETTag(consumes<View<pat::MET>>(iConfig.getParameter<edm::InputTag>("srcMET"))),
 theTauTag(consumes<pat::TauCollection>(iConfig.getParameter<edm::InputTag>("tauCollection")))
 {
-    produces<double>("METdxUP_EES");
-    produces<double>("METdyUP_EES");
-    produces<double>("METdxDOWN_EES");
-    produces<double>("METdyDOWN_EES");
+    produces<double>("METdxUPEES");
+    produces<double>("METdyUPEES");
+    produces<double>("METdxDOWNEES");
+    produces<double>("METdyDOWNEES");
     
 }
 
@@ -143,10 +143,10 @@ void ShiftMETforEES::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     //cout << "SHIFTED UP  : " << *dx_UP_ptr << " / " << *dy_UP_ptr << endl;
     //cout << "SHIFTED DOWN: " << *dx_DOWN_ptr << " / " << *dy_DOWN_ptr << endl;
 
-    iEvent.put( std::move(dx_UP_ptr)  , "METdxUP_EES"   );
-    iEvent.put( std::move(dy_UP_ptr)  , "METdyUP_EES"   );
-    iEvent.put( std::move(dx_DOWN_ptr), "METdxDOWN_EES" );
-    iEvent.put( std::move(dy_DOWN_ptr), "METdyDOWN_EES" );
+    iEvent.put( std::move(dx_UP_ptr)  , "METdxUPEES"   );
+    iEvent.put( std::move(dy_UP_ptr)  , "METdyUPEES"   );
+    iEvent.put( std::move(dx_DOWN_ptr), "METdxDOWNEES" );
+    iEvent.put( std::move(dy_DOWN_ptr), "METdyDOWNEES" );
     
 }
 

--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -107,22 +107,22 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "byMediumCombinedIsolationDeltaBetaCorr3Hits",
     "byTightCombinedIsolationDeltaBetaCorr3Hits",
     
-    "byVLooseIsolationMVArun2v1DBoldDMwLT",
-    "byLooseIsolationMVArun2v1DBoldDMwLT",
-    "byMediumIsolationMVArun2v1DBoldDMwLT",
-    "byTightIsolationMVArun2v1DBoldDMwLT",
-    "byVTightIsolationMVArun2v1DBoldDMwLT",
+    //"byVLooseIsolationMVArun2v1DBoldDMwLT",
+    //"byLooseIsolationMVArun2v1DBoldDMwLT",
+    //"byMediumIsolationMVArun2v1DBoldDMwLT",
+    //"byTightIsolationMVArun2v1DBoldDMwLT",
+    //"byVTightIsolationMVArun2v1DBoldDMwLT",
 
-    "byVLooseIsolationMVArun2v1DBnewDMwLT",    
-    "byLooseIsolationMVArun2v1DBnewDMwLT",
-    "byMediumIsolationMVArun2v1DBnewDMwLT",
-    "byTightIsolationMVArun2v1DBnewDMwLT",
-    "byVTightIsolationMVArun2v1DBnewDMwLT",
+    //"byVLooseIsolationMVArun2v1DBnewDMwLT",
+    //"byLooseIsolationMVArun2v1DBnewDMwLT",
+    //"byMediumIsolationMVArun2v1DBnewDMwLT",
+    //"byTightIsolationMVArun2v1DBnewDMwLT",
+    //"byVTightIsolationMVArun2v1DBnewDMwLT",
 
-    "byLooseIsolationMVArun2v1DBdR03oldDMwLT",
-    "byMediumIsolationMVArun2v1DBdR03oldDMwLT",
-    "byTightIsolationMVArun2v1DBdR03oldDMwLT",
-    "byVTightIsolationMVArun2v1DBdR03oldDMwLT",
+    //"byLooseIsolationMVArun2v1DBdR03oldDMwLT",
+    //"byMediumIsolationMVArun2v1DBdR03oldDMwLT",
+    //"byTightIsolationMVArun2v1DBdR03oldDMwLT",
+    //"byVTightIsolationMVArun2v1DBdR03oldDMwLT",
     
     "againstMuonLoose3",
     "againstMuonTight3",
@@ -141,17 +141,17 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "byVTightIsolationMVArun2017v2DBoldDMwLT2017", //FRA syncApr2018
     "byVVTightIsolationMVArun2017v2DBoldDMwLT2017", //FRA syncApr2018
     
-    "byVLooseIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
-    "byLooseIsolationMVArun2017v1DBoldDMwLT2017",  //FRA syncApr2018
-    "byMediumIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
-    "byTightIsolationMVArun2017v1DBoldDMwLT2017",  //FRA syncApr2018
-    "byVTightIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
+    //"byVLooseIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
+    //"byLooseIsolationMVArun2017v1DBoldDMwLT2017",  //FRA syncApr2018
+    //"byMediumIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
+    //"byTightIsolationMVArun2017v1DBoldDMwLT2017",  //FRA syncApr2018
+    //"byVTightIsolationMVArun2017v1DBoldDMwLT2017", //FRA syncApr2018
     
-    "byVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
-    "byLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
-    "byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
-    "byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
-    "byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
+    //"byVLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
+    //"byLooseIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
+    //"byMediumIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
+    //"byTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017",  //FRA syncApr2018
+    //"byVTightIsolationMVArun2017v2DBoldDMdR0p3wLT2017", //FRA syncApr2018
     
     "byVVVLooseDeepTau2017v2p1VSjet",
     "byVVLooseDeepTau2017v2p1VSjet", 
@@ -189,9 +189,9 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "chargedIsoPtSum",
     "neutralIsoPtSum",
     "puCorrPtSum",
-    "byIsolationMVArun2017v1DBoldDMwLTraw2017",      //FRA syncApr2018
+    //"byIsolationMVArun2017v1DBoldDMwLTraw2017",      //FRA syncApr2018
     "byIsolationMVArun2017v2DBoldDMwLTraw2017",      //FRA syncApr2018
-    "byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017", //FRA syncApr2018
+    //"byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017", //FRA syncApr2018
     "byDeepTau2017v2p1VSjetraw",  
     "byDeepTau2017v2p1VSeraw",  
     "byDeepTau2017v2p1VSmuraw",

--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -282,35 +282,42 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       //  shiftMass = 1.;
       //}
     }
-    
-    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2016#MC_Matching
-    //https://github.com/KIT-CMS/Artus/blob/dictchanges/KappaAnalysis/src/Utility/GeneratorInfo.cc#L77-L165    
-    GenParticle closest = (GenParticle) (*genHandle)[0] ;
-    double closestDR = 999;
+
     int genmatch = 6; // 6 = fake
     if (isTauMatched)
-      {
-        genmatch = 5;
-      }else{
-      for (unsigned int iGen = 0; iGen < genHandle->size(); iGen++)
-	{
-	  const GenParticle& genP = (*genHandle)[iGen];
-
-	  double tmpDR = deltaR(l.p4(), genP.p4());
-	  if (tmpDR < closestDR)
-	    {
-	      closest = genP;
-	      closestDR = tmpDR;
-	    }
-	}
-      if (closestDR < 0.2){
-        int pdgId = std::abs(closest.pdgId());
-        if (pdgId == 11 && closest.pt() > 8. && closest.statusFlags().isPrompt()) genmatch = 1;
-        else if (pdgId == 13 && closest.pt() > 8. && closest.statusFlags().isPrompt()) genmatch = 2;
-	else if (pdgId == 11 && closest.pt() > 8. && closest.statusFlags().isDirectPromptTauDecayProduct()) genmatch = 3;
-        else if (pdgId == 13 && closest.pt() > 8. && closest.statusFlags().isDirectPromptTauDecayProduct()) genmatch = 4;
-      }
+    {
+      genmatch = 5;
     }
+    else // !isTauMatched
+    {
+      //https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2016#MC_Matching
+      //https://github.com/KIT-CMS/Artus/blob/dictchanges/KappaAnalysis/src/Utility/GeneratorInfo.cc#L77-L165
+      if (genHandle.isValid())
+      {
+        GenParticle closest = (GenParticle) (*genHandle)[0] ;
+        double closestDR = 999;
+
+        for (unsigned int iGen = 0; iGen < genHandle->size(); iGen++)
+        {
+          const GenParticle& genP = (*genHandle)[iGen];
+          double tmpDR = deltaR(l.p4(), genP.p4());
+          if (tmpDR < closestDR)
+          {
+            closest = genP;
+            closestDR = tmpDR;
+          }
+        }
+
+        if (closestDR < 0.2)
+        {
+          int pdgId = std::abs(closest.pdgId());
+          if      (pdgId == 11 && closest.pt() > 8. && closest.statusFlags().isPrompt()) genmatch = 1;
+          else if (pdgId == 13 && closest.pt() > 8. && closest.statusFlags().isPrompt()) genmatch = 2;
+          else if (pdgId == 11 && closest.pt() > 8. && closest.statusFlags().isDirectPromptTauDecayProduct()) genmatch = 3;
+          else if (pdgId == 13 && closest.pt() > 8. && closest.statusFlags().isDirectPromptTauDecayProduct()) genmatch = 4;
+        }
+      } // end genHandle.isValid()
+    } // end !isTauMatched
 
     //E->tau ES
 

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -316,7 +316,7 @@ updatedTauName = "slimmedTausNewID" #name of pat::Tau collection with new tau-Id
 
 tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = True,
                     updatedTauName = updatedTauName,
-                    toKeep = ["deepTau2017v2p1", "2017v1", "2017v2", "dR0p32017v2"] #Always keep because names are hardcoded in TauFiller.cc and HTauTauNtuplizer.cc
+                    toKeep = ["deepTau2017v2p1", "2017v2"]  #["2017v1", "dR0p32017v2"]
 )
 
 tauIdEmbedder.runTauID()

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -458,8 +458,8 @@ process.softTaus = cms.EDProducer("TauFiller",
    NominalTESCorrection1PrPi0       = NomTESCor1PrPi0,
    NominalTESCorrection3Pr          = NomTESCor3Pr,
    NominalTESCorrection3PrPi0       = NomTESCor3PrPi0,
-   NominalEFakeESCorrection1Pr      = NominalEFakeESCor1Pr, 
-   NominalEFakeESCorrection1PrPi0   = NominalEFakeESCor1PrPi0, 
+   NominalEFakeESCorrection1Pr       = NominalEFakeESCor1Pr,
+   NominalEFakeESCorrection1PrPi0    = NominalEFakeESCor1PrPi0,
    NominalEFakeESUncertainty1Pr      = NominalEFakeESUnc1Pr, 
    NominalEFakeESUncertainty1PrPi0   = NominalEFakeESUnc1PrPi0, 
 
@@ -662,9 +662,16 @@ else:
                                              tauCollection = cms.InputTag("softTaus")
                                              )
 
+    # add variables with MET shifted for EES corrections (E->tau ES)
+    process.ShiftMETforEES = cms.EDProducer ("ShiftMETforEES",
+                                             srcMET  = cms.InputTag("slimmedMETs","","TEST"),
+                                             tauCollection = cms.InputTag("softTaus")
+                                             )
+
     process.METSequence += process.fullPatMetSequence
     process.METSequence += process.METSignificance
     process.METSequence += process.ShiftMETforTES
+    process.METSequence += process.ShiftMETforEES
 
 
 ## Since release 10_2_X (X >=7) this is included in CMSSW
@@ -730,7 +737,11 @@ process.SVllCand = cms.EDProducer("ClassicSVfitInterface",
                                   METdxUP    = cms.InputTag("ShiftMETforTES", "METdxUP"),
                                   METdyUP    = cms.InputTag("ShiftMETforTES", "METdyUP"),
                                   METdxDOWN  = cms.InputTag("ShiftMETforTES", "METdxDOWN"),
-                                  METdyDOWN  = cms.InputTag("ShiftMETforTES", "METdyDOWN")
+                                  METdyDOWN  = cms.InputTag("ShiftMETforTES", "METdyDOWN"),
+                                  METdxUP_EES   = cms.InputTag("ShiftMETforEES", "METdxUP_EES"),
+                                  METdyUP_EES   = cms.InputTag("ShiftMETforEES", "METdyUP_EES"),
+                                  METdxDOWN_EES = cms.InputTag("ShiftMETforEES", "METdxDOWN_EES"),
+                                  METdyDOWN_EES = cms.InputTag("ShiftMETforEES", "METdyDOWN_EES")
 )
 #else:
 #    print "Using STANDALONE_SV_FIT"
@@ -755,7 +766,11 @@ process.SVbypass = cms.EDProducer ("SVfitBypass",
                                     METdxUP    = cms.InputTag("ShiftMETforTES", "METdxUP"),
                                     METdyUP    = cms.InputTag("ShiftMETforTES", "METdyUP"),
                                     METdxDOWN  = cms.InputTag("ShiftMETforTES", "METdxDOWN"),
-                                    METdyDOWN  = cms.InputTag("ShiftMETforTES", "METdyDOWN")
+                                    METdyDOWN  = cms.InputTag("ShiftMETforTES", "METdyDOWN"),
+                                    METdxUP_EES   = cms.InputTag("ShiftMETforEES", "METdxUP"),
+                                    METdyUP_EES   = cms.InputTag("ShiftMETforEES", "METdyUP"),
+                                    METdxDOWN_EES = cms.InputTag("ShiftMETforEES", "METdxDOWN"),
+                                    METdyDOWN_EES = cms.InputTag("ShiftMETforEES", "METdyDOWN")
 )
 
 

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -76,7 +76,7 @@ if IsMC:
   if YEAR == 2017:
     process.GlobalTag.globaltag = '94X_mc2017_realistic_v17'        # 2017 MC
   if YEAR == 2018:
-    process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v19'  # 2018 MC
+    process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v20'  # 2018 MC
 else :
   if YEAR == 2016:
     process.GlobalTag.globaltag = '94X_dataRun2_v10'                # 2016 Data
@@ -84,9 +84,9 @@ else :
     process.GlobalTag.globaltag = '94X_dataRun2_v11'                # 2017 Data
   if YEAR == 2018:
     if PERIOD=="D":
-        process.GlobalTag.globaltag = '102X_dataRun2_Prompt_v14'    # 2018D Data
+        process.GlobalTag.globaltag = '102X_dataRun2_Prompt_v15'    # 2018D Data
     else:
-        process.GlobalTag.globaltag = '102X_dataRun2_v11'           # 2018ABC Data
+        process.GlobalTag.globaltag = '102X_dataRun2_v12'           # 2018ABC Data
 
 print "GT: ",process.GlobalTag.globaltag
 

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -738,10 +738,10 @@ process.SVllCand = cms.EDProducer("ClassicSVfitInterface",
                                   METdyUP    = cms.InputTag("ShiftMETforTES", "METdyUP"),
                                   METdxDOWN  = cms.InputTag("ShiftMETforTES", "METdxDOWN"),
                                   METdyDOWN  = cms.InputTag("ShiftMETforTES", "METdyDOWN"),
-                                  METdxUP_EES   = cms.InputTag("ShiftMETforEES", "METdxUP_EES"),
-                                  METdyUP_EES   = cms.InputTag("ShiftMETforEES", "METdyUP_EES"),
-                                  METdxDOWN_EES = cms.InputTag("ShiftMETforEES", "METdxDOWN_EES"),
-                                  METdyDOWN_EES = cms.InputTag("ShiftMETforEES", "METdyDOWN_EES")
+                                  METdxUP_EES   = cms.InputTag("ShiftMETforEES", "METdxUPEES"),
+                                  METdyUP_EES   = cms.InputTag("ShiftMETforEES", "METdyUPEES"),
+                                  METdxDOWN_EES = cms.InputTag("ShiftMETforEES", "METdxDOWNEES"),
+                                  METdyDOWN_EES = cms.InputTag("ShiftMETforEES", "METdyDOWNEES")
 )
 #else:
 #    print "Using STANDALONE_SV_FIT"
@@ -767,10 +767,10 @@ process.SVbypass = cms.EDProducer ("SVfitBypass",
                                     METdyUP    = cms.InputTag("ShiftMETforTES", "METdyUP"),
                                     METdxDOWN  = cms.InputTag("ShiftMETforTES", "METdxDOWN"),
                                     METdyDOWN  = cms.InputTag("ShiftMETforTES", "METdyDOWN"),
-                                    METdxUP_EES   = cms.InputTag("ShiftMETforEES", "METdxUP"),
-                                    METdyUP_EES   = cms.InputTag("ShiftMETforEES", "METdyUP"),
-                                    METdxDOWN_EES = cms.InputTag("ShiftMETforEES", "METdxDOWN"),
-                                    METdyDOWN_EES = cms.InputTag("ShiftMETforEES", "METdyDOWN")
+                                    METdxUP_EES   = cms.InputTag("ShiftMETforEES", "METdxUPEES"),
+                                    METdyUP_EES   = cms.InputTag("ShiftMETforEES", "METdyUPEES"),
+                                    METdxDOWN_EES = cms.InputTag("ShiftMETforEES", "METdxDOWNEES"),
+                                    METdyDOWN_EES = cms.InputTag("ShiftMETforEES", "METdyDOWNEES")
 )
 
 


### PR DESCRIPTION
Need to spread the ele->tau ES to the rest of the framework.
A lot of changes made:
- fixed e->tau ES in TauFiller: now it's decoupled from the TES
- added branches "daughters_EleUp/Down" to save the results from EES (electron ES)
- added shift of the MET due to EES (new plugin named ShiftMETforEES.cc)
- added EES and new shifted MET in ClassicSVfitInterface and SVfitByPass and in the python producer

EDIT:
- the branches "TauUpExists" and "TauDownExists" do not longer exist: since they were exactly the same they are replaced with the branch "isTESShifted"
- added a new branch "isEESShifted" which tells us of the lepton is shifted for e->tau ES