### PR TITLE
split E/B e->tauh ES corrections, asymmetric uncertainties

### DIFF
--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -53,19 +53,29 @@ class TauFiller : public edm::EDProducer {
   const CutSet<pat::Tau> flags;
   const bool ApplyTESCentralCorr; // shift the central TES value
   //const double NominalTESCorrection;     // value of correction of centrale TES value used in HIG-17-002, same for all DMs
-  const double NominalTESCorrection1Pr;    // DM==0  - correction of central TES
-  const double NominalTESCorrection1PrPi0; // DM==1  - correction of central TES
-  const double NominalTESCorrection3Pr;    // DM==10 - correction of central TES
-  const double NominalTESCorrection3PrPi0;    // DM==11 - correction of central TES
-  const double NominalTESUncertainty1Pr;      // Up/Down uncertainty for TES 
-  const double NominalTESUncertainty1PrPi0;      // Up/Down uncertainty for TES 
-  const double NominalTESUncertainty3Pr;      // Up/Down uncertainty for TES 
-  const double NominalTESUncertainty3PrPi0;      // Up/Down uncertainty for TES 
+  const double NominalTESCorrectionDM0;    // DM==0  - correction of central TES
+  const double NominalTESCorrectionDM1; // DM==1  - correction of central TES
+  const double NominalTESCorrectionDM10;    // DM==10 - correction of central TES
+  const double NominalTESCorrectionDM11;    // DM==11 - correction of central TES
+  const double NominalTESUncertaintyDM0;      // Up/Down uncertainty for TES 
+  const double NominalTESUncertaintyDM1;      // Up/Down uncertainty for TES 
+  const double NominalTESUncertaintyDM10;      // Up/Down uncertainty for TES 
+  const double NominalTESUncertaintyDM11;      // Up/Down uncertainty for TES 
 
-  const double NominalEFakeESCorrection1Pr;    // DM==0  - correction of central e->tauh ES
-  const double NominalEFakeESCorrection1PrPi0; // DM==1  - correction of central e->tauh ES
-  const double NominalEFakeESUncertainty1Pr;    // DM==0  - correction of central e->tauh ES
-  const double NominalEFakeESUncertainty1PrPi0; // DM==1  - correction of central e->tauh ES
+  const double NominalEFakeESCorrectionDM0B;       // DM==0 - barrel - correction of central e->tauh ES
+  const double NominalEFakeESUncertaintyDM0BUp;    // DM==0 - barrel - up uncertainty e->tauh ES
+  const double NominalEFakeESUncertaintyDM0BDown;  // DM==0 - barrel - down uncertainty e->tauh ES
+  const double NominalEFakeESCorrectionDM1B;       // DM==1 - barrel - correction of central e->tauh ES
+  const double NominalEFakeESUncertaintyDM1BUp;    // DM==1 - barrel - up uncertainty e->tauh ES
+  const double NominalEFakeESUncertaintyDM1BDown;  // DM==1 - barrel - down uncertainty e->tauh ES
+
+  const double NominalEFakeESCorrectionDM0E;       // DM==0 - endcaps - correction of central e->tauh ES
+  const double NominalEFakeESUncertaintyDM0EUp;    // DM==0 - endcaps - up uncertainty e->tauh ES
+  const double NominalEFakeESUncertaintyDM0EDown;  // DM==0 - endcaps - down uncertainty e->tauh ES
+  const double NominalEFakeESCorrectionDM1E;       // DM==1 - endcaps - correction of central e->tauh ES
+  const double NominalEFakeESUncertaintyDM1EUp;    // DM==1 - endcaps - up uncertainty e->tauh ES
+  const double NominalEFakeESUncertaintyDM1EDown;  // DM==1 - endcaps - down uncertainty e->tauh ES
+
 
 
   vector<string> tauIntDiscrims_; // tau discrims to be added as userInt
@@ -82,18 +92,26 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
   flags(iConfig.getParameter<ParameterSet>("flags")), 
   ApplyTESCentralCorr(iConfig.getParameter<bool>("ApplyTESCentralCorr")),
   //NominalTESCorrection(iConfig.getParameter<double>("NominalTESCorrection")), // used for HIG-17-002, same for all values
-  NominalTESCorrection1Pr(iConfig.getParameter<double>("NominalTESCorrection1Pr")),
-  NominalTESCorrection1PrPi0(iConfig.getParameter<double>("NominalTESCorrection1PrPi0")),
-  NominalTESCorrection3Pr(iConfig.getParameter<double>("NominalTESCorrection3Pr")),
-  NominalTESCorrection3PrPi0(iConfig.getParameter<double>("NominalTESCorrection3PrPi0")),
-  NominalTESUncertainty1Pr(iConfig.getParameter<double>("NominalTESUncertainty1Pr")),
-  NominalTESUncertainty1PrPi0(iConfig.getParameter<double>("NominalTESUncertainty1PrPi0")),
-  NominalTESUncertainty3Pr(iConfig.getParameter<double>("NominalTESUncertainty3Pr")),
-  NominalTESUncertainty3PrPi0(iConfig.getParameter<double>("NominalTESUncertainty3PrPi0")),
-  NominalEFakeESCorrection1Pr(iConfig.getParameter<double>("NominalEFakeESCorrection1Pr")),
-  NominalEFakeESCorrection1PrPi0(iConfig.getParameter<double>("NominalEFakeESCorrection1PrPi0")),
-  NominalEFakeESUncertainty1Pr(iConfig.getParameter<double>("NominalEFakeESUncertainty1Pr")),
-  NominalEFakeESUncertainty1PrPi0(iConfig.getParameter<double>("NominalEFakeESUncertainty1PrPi0"))
+  NominalTESCorrectionDM0(iConfig.getParameter<double>("NominalTESCorrectionDM0")),
+  NominalTESCorrectionDM1(iConfig.getParameter<double>("NominalTESCorrectionDM1")),
+  NominalTESCorrectionDM10(iConfig.getParameter<double>("NominalTESCorrectionDM10")),
+  NominalTESCorrectionDM11(iConfig.getParameter<double>("NominalTESCorrectionDM11")),
+  NominalTESUncertaintyDM0(iConfig.getParameter<double>("NominalTESUncertaintyDM0")),
+  NominalTESUncertaintyDM1(iConfig.getParameter<double>("NominalTESUncertaintyDM1")),
+  NominalTESUncertaintyDM10(iConfig.getParameter<double>("NominalTESUncertaintyDM10")),
+  NominalTESUncertaintyDM11(iConfig.getParameter<double>("NominalTESUncertaintyDM11")),
+  NominalEFakeESCorrectionDM0B(iConfig.getParameter<double>("NominalEFakeESCorrectionDM0B")),
+  NominalEFakeESUncertaintyDM0BUp(iConfig.getParameter<double>("NominalEFakeESUncertaintyDM0BUp")),
+  NominalEFakeESUncertaintyDM0BDown(iConfig.getParameter<double>("NominalEFakeESUncertaintyDM0BDown")),
+  NominalEFakeESCorrectionDM1B(iConfig.getParameter<double>("NominalEFakeESCorrectionDM1B")),
+  NominalEFakeESUncertaintyDM1BUp(iConfig.getParameter<double>("NominalEFakeESUncertaintyDM1BUp")),
+  NominalEFakeESUncertaintyDM1BDown(iConfig.getParameter<double>("NominalEFakeESUncertaintyDM1BDown")),
+  NominalEFakeESCorrectionDM0E(iConfig.getParameter<double>("NominalEFakeESCorrectionDM0E")),
+  NominalEFakeESUncertaintyDM0EUp(iConfig.getParameter<double>("NominalEFakeESUncertaintyDM0EUp")),
+  NominalEFakeESUncertaintyDM0EDown(iConfig.getParameter<double>("NominalEFakeESUncertaintyDM0EDown")),
+  NominalEFakeESCorrectionDM1E(iConfig.getParameter<double>("NominalEFakeESCorrectionDM1E")),
+  NominalEFakeESUncertaintyDM1EUp(iConfig.getParameter<double>("NominalEFakeESUncertaintyDM1EUp")),
+  NominalEFakeESUncertaintyDM1EDown(iConfig.getParameter<double>("NominalEFakeESUncertaintyDM1EDown"))
 
 {
   produces<pat::TauCollection>();
@@ -227,12 +245,14 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     pat::Tau l(*((*tauHandle)[itau].get()));
     
     // Nominal TES Correction
-    double Shift1Pr    = 1. + NominalTESCorrection1Pr/100.;
-    double Shift1PrPi0 = 1. + NominalTESCorrection1PrPi0/100.;
-    double Shift3Pr    = 1. + NominalTESCorrection3Pr/100.;
-    double Shift3PrPi0  = 1. + NominalTESCorrection3PrPi0/100.;
-    double EFakeShift1Pr    = 1. + NominalEFakeESCorrection1Pr/100.;
-    double EFakeShift1PrPi0 = 1. + NominalEFakeESCorrection1PrPi0/100.;
+    double Shift1Pr    = 1. + NominalTESCorrectionDM0/100.;
+    double Shift1PrPi0 = 1. + NominalTESCorrectionDM1/100.;
+    double Shift3Pr    = 1. + NominalTESCorrectionDM10/100.;
+    double Shift3PrPi0  = 1. + NominalTESCorrectionDM11/100.;
+    double EFakeShift1PrB    = 1. + NominalEFakeESCorrectionDM0B/100.;
+    double EFakeShift1PrE    = 1. + NominalEFakeESCorrectionDM0E/100.;
+    double EFakeShift1PrPi0B = 1. + NominalEFakeESCorrectionDM1B/100.;
+    double EFakeShift1PrPi0E = 1. + NominalEFakeESCorrectionDM1E/100.;
 
     double shiftP = 1.;
     double shiftMass = 1.;
@@ -323,13 +343,18 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     if(ApplyTESCentralCorr){
       if ((genmatch == 1 || genmatch == 3) &&l.decayMode()==0)  {
-	shiftP    = EFakeShift1Pr;     // 1prong
+	shiftP    = EFakeShift1PrB;     // 1prong
+	if (fabs(l.eta())> 1.558) shiftP    = EFakeShift1PrE;
 	shiftMass = 1.;
 	isEESShifted = true;
       }
       if ((genmatch == 1 || genmatch == 3) &&l.decayMode()==1) {
-	shiftP    = EFakeShift1PrPi0;  // 1prong+pi0
-	shiftMass = EFakeShift1PrPi0;
+	shiftP    = EFakeShift1PrPi0B;  // 1prong+pi0
+	shiftMass = EFakeShift1PrPi0B;
+	if (fabs(l.eta())> 1.558) {
+	  shiftP    = EFakeShift1PrPi0E;
+	  shiftMass = EFakeShift1PrPi0E;
+	}
 	isEESShifted = true;
       }
 
@@ -354,30 +379,30 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
       if (l.decayMode()==0)       // 1prong
       {
-        udshiftP[0]    =  Shift1Pr + (NominalTESUncertainty1Pr/100.); //udShift[0]; // up
-        udshiftP[1]    =  Shift1Pr - (NominalTESUncertainty1Pr/100.); //udShift[1]; // down
+        udshiftP[0]    =  Shift1Pr + (NominalTESUncertaintyDM0/100.); //udShift[0]; // up
+        udshiftP[1]    =  Shift1Pr - (NominalTESUncertaintyDM0/100.); //udShift[1]; // down
         udshiftMass[0] = udshiftMass[1] = 1.; // no mass shift for pi0
       }
       else if (l.decayMode()==1)  // 1prong+pi0
       {
-        udshiftP[0]    = Shift1PrPi0 + (NominalTESUncertainty1PrPi0/100.); //udShift[0]; // up
-        udshiftP[1]    = Shift1PrPi0 - (NominalTESUncertainty1PrPi0/100.); //udShift[1]; // down
-        udshiftMass[0] = Shift1PrPi0 + (NominalTESUncertainty1PrPi0/100.); //udShift[0]; // up
-        udshiftMass[1] = Shift1PrPi0 - (NominalTESUncertainty1PrPi0/100.); //udShift[1]; // down
+        udshiftP[0]    = Shift1PrPi0 + (NominalTESUncertaintyDM1/100.); //udShift[0]; // up
+        udshiftP[1]    = Shift1PrPi0 - (NominalTESUncertaintyDM1/100.); //udShift[1]; // down
+        udshiftMass[0] = Shift1PrPi0 + (NominalTESUncertaintyDM1/100.); //udShift[0]; // up
+        udshiftMass[1] = Shift1PrPi0 - (NominalTESUncertaintyDM1/100.); //udShift[1]; // down
       }
       else if (l.decayMode()==10) // 3prong
       {
-        udshiftP[0]    = Shift3Pr + (NominalTESUncertainty3Pr/100.); //udShift[0]; // up
-        udshiftP[1]    = Shift3Pr - (NominalTESUncertainty3Pr/100.); //udShift[1]; // down
-        udshiftMass[0] = Shift3Pr + (NominalTESUncertainty3Pr/100.); //udShift[0]; // up
-        udshiftMass[1] = Shift3Pr - (NominalTESUncertainty3Pr/100.); //udShift[1]; // down
+        udshiftP[0]    = Shift3Pr + (NominalTESUncertaintyDM10/100.); //udShift[0]; // up
+        udshiftP[1]    = Shift3Pr - (NominalTESUncertaintyDM10/100.); //udShift[1]; // down
+        udshiftMass[0] = Shift3Pr + (NominalTESUncertaintyDM10/100.); //udShift[0]; // up
+        udshiftMass[1] = Shift3Pr - (NominalTESUncertaintyDM10/100.); //udShift[1]; // down
       }
       else if (l.decayMode()==11) // 3prong
       {
-        udshiftP[0]    = Shift3PrPi0 + (NominalTESUncertainty3PrPi0/100.); //udShift[0]; // up
-        udshiftP[1]    = Shift3PrPi0 - (NominalTESUncertainty3PrPi0/100.); //udShift[1]; // down
-        udshiftMass[0] = Shift3PrPi0 + (NominalTESUncertainty3PrPi0/100.); //udShift[0]; // up
-        udshiftMass[1] = Shift3PrPi0 - (NominalTESUncertainty3PrPi0/100.); //udShift[1]; // down
+        udshiftP[0]    = Shift3PrPi0 + (NominalTESUncertaintyDM11/100.); //udShift[0]; // up
+        udshiftP[1]    = Shift3PrPi0 - (NominalTESUncertaintyDM11/100.); //udShift[1]; // down
+        udshiftMass[0] = Shift3PrPi0 + (NominalTESUncertaintyDM11/100.); //udShift[0]; // up
+        udshiftMass[1] = Shift3PrPi0 - (NominalTESUncertaintyDM11/100.); //udShift[1]; // down
       }
       else  // these are not real taus and will be rejected --> we don't care about the shift and just put 1
       {
@@ -435,16 +460,26 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     float udEFakeshiftMass[2] = {1., 1.};
 
     if ((genmatch == 1 || genmatch == 3) &&l.decayMode()==0){
-      udEFakeshiftP[0]    =  EFakeShift1Pr + (NominalEFakeESUncertainty1Pr/100.); // up
-      udEFakeshiftP[1]    =  EFakeShift1Pr - (NominalEFakeESUncertainty1Pr/100.); // down
+      udEFakeshiftP[0]    =  EFakeShift1PrB + (NominalEFakeESUncertaintyDM0BUp/100.); // up
+      udEFakeshiftP[1]    =  EFakeShift1PrB - (NominalEFakeESUncertaintyDM0BDown/100.); // down
+      if(fabs(l.eta())>1.558){
+	udEFakeshiftP[0]    =  EFakeShift1PrE + (NominalEFakeESUncertaintyDM0EUp/100.); // up
+	udEFakeshiftP[1]    =  EFakeShift1PrE - (NominalEFakeESUncertaintyDM0EDown/100.); // down
+      }
       udEFakeshiftMass[0] = udEFakeshiftMass[1] = 1.; // no mass shift for pi0
 
     }
     if ((genmatch == 1 || genmatch == 3) &&l.decayMode()==1){
-      udEFakeshiftP[0]    = EFakeShift1PrPi0 + (NominalEFakeESUncertainty1PrPi0/100.); // up
-      udEFakeshiftP[1]    = EFakeShift1PrPi0 - (NominalEFakeESUncertainty1PrPi0/100.); // down
-      udEFakeshiftMass[0] = EFakeShift1PrPi0 + (NominalEFakeESUncertainty1PrPi0/100.); // up
-      udEFakeshiftMass[1] = EFakeShift1PrPi0 - (NominalEFakeESUncertainty1PrPi0/100.); // down
+      udEFakeshiftP[0]    = EFakeShift1PrPi0B + (NominalEFakeESUncertaintyDM1BUp/100.);   // up
+      udEFakeshiftP[1]    = EFakeShift1PrPi0B - (NominalEFakeESUncertaintyDM1BDown/100.); // down
+      udEFakeshiftMass[0] = EFakeShift1PrPi0B + (NominalEFakeESUncertaintyDM1BUp/100.);   // up
+      udEFakeshiftMass[1] = EFakeShift1PrPi0B - (NominalEFakeESUncertaintyDM1BDown/100.); // down
+      if(fabs(l.eta())>1.558){
+	udEFakeshiftP[0]    = EFakeShift1PrPi0E + (NominalEFakeESUncertaintyDM1EUp/100.);   // up
+	udEFakeshiftP[1]    = EFakeShift1PrPi0E - (NominalEFakeESUncertaintyDM1EDown/100.); // down
+	udEFakeshiftMass[0] = EFakeShift1PrPi0E + (NominalEFakeESUncertaintyDM1EUp/100.);   // up
+	udEFakeshiftMass[1] = EFakeShift1PrPi0E - (NominalEFakeESUncertaintyDM1EDown/100.); // down
+      }
     }
 
     if (ApplyTESCentralCorr && isEESShifted)

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -76,7 +76,7 @@ if IsMC:
   if YEAR == 2017:
     process.GlobalTag.globaltag = '94X_mc2017_realistic_v17'        # 2017 MC
   if YEAR == 2018:
-    process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v19'  # 2018 MC
+    process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v20'  # 2018 MC
 else :
   if YEAR == 2016:
     process.GlobalTag.globaltag = '94X_dataRun2_v10'                # 2016 Data

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -414,12 +414,13 @@ NomTESCorDM10     = cms.double(0.0)  # DecayMode==10
 NomTESCorDM11     = cms.double(2.6)  # DecayMode==11
 
 #EES BARREL
-NomlEFakeESCorDM0B     = cms.double(0.679) #DecayMode==0
+NomEFakeESCorDM0B     = cms.double(0.679) #DecayMode==0
 NomEFakeESUncDM0BUp    = cms.double(0.806) #DecayMode==0
 NomEFakeESUncDM0BDown  = cms.double(0.982) #DecayMode==0
 NomEFakeESCorDM1B      = cms.double(3.389) #DecayMode==1
 NomEFakeESUncDM1BUp    = cms.double(1.168) #DecayMode==1
 NomEFakeESUncDM1BDown  = cms.double(2.475) #DecayMode==1
+
 #EES ENDCAP
 NomEFakeESCorDM0E      = cms.double(-3.5)   #DecayMode==0
 NomEFakeESUncDM0EUp    = cms.double(1.808)  #DecayMode==0

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -76,7 +76,7 @@ if IsMC:
   if YEAR == 2017:
     process.GlobalTag.globaltag = '94X_mc2017_realistic_v17'        # 2017 MC
   if YEAR == 2018:
-    process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v20'  # 2018 MC
+    process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v19'  # 2018 MC
 else :
   if YEAR == 2016:
     process.GlobalTag.globaltag = '94X_dataRun2_v10'                # 2016 Data

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -365,83 +365,121 @@ process.cleanTaus = cms.EDProducer("PATTauCleaner",
 
 # TES corrections: https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauIDRecommendationForRun2#Tau_energy_scale_for_MVA_tau_id
 # for DeepTau: https://indico.cern.ch/event/864131/contributions/3644021/attachments/1946837/3230164/Izaak_TauPOG_TauES_20191118.pdf
+
+# EES corrections: https://indico.cern.ch/event/868279/contributions/3665970/attachments/1959265/3267731/FES_9Dec_explained.pdf
+
 # NominalTESCorrection=-1#in percent\
 APPLYTESCORRECTION = APPLYTESCORRECTION if IsMC else False # always false if data
 
 # 2016 data - MVAoldDM2017v2
-#NomTESUnc1Pr      = cms.double(1.0)  # in percent, up/down uncertainty of TES
-#NomTESUnc1PrPi0   = cms.double(0.9)  # in percent, up/down uncertainty of TES
-#NomTESUnc3Pr      = cms.double(1.1)  # in percent, up/down uncertainty of TES
-#NomTESUnc3PrPi0   = --> Missing <--  # in percent, up/down uncertainty of TES
-#NomTESCor1Pr      = cms.double(-0.6) # DecayMode==0
-#NomTESCor1PrPi0   = cms.double(-0.5) # DecayMode==1
-#NomTESCor3Pr      = cms.double(0.0)  # DecayMode==10
-#NomTESCor3PrPi0   = --> Missing <--  # DecayMode==11
+#NomTESUncDM0      = cms.double(1.0)  # in percent, up/down uncertainty of TES
+#NomTESUncDM1   = cms.double(0.9)  # in percent, up/down uncertainty of TES
+#NomTESUncDM10      = cms.double(1.1)  # in percent, up/down uncertainty of TES
+#NomTESUncDM11   = --> Missing <--  # in percent, up/down uncertainty of TES
+#NomTESCorDM0      = cms.double(-0.6) # DecayMode==0
+#NomTESCorDM1   = cms.double(-0.5) # DecayMode==1
+#NomTESCorDM10      = cms.double(0.0)  # DecayMode==10
+#NomTESCorDM11   = --> Missing <--  # DecayMode==11
 
 # 2017 data - MVAoldDM2017v2
 #if YEAR == 2017:
-#    NomTESUnc1Pr      = cms.double(0.8)  # in percent, up/down uncertainty of TES
-#    NomTESUnc1PrPi0   = cms.double(0.8)  # in percent, up/down uncertainty of TES
-#    NomTESUnc3Pr      = cms.double(0.9)  # in percent, up/down uncertainty of TES
-#    NomTESUnc3PrPi0   = cms.double(1.0)  # in percent, up/down uncertainty of TES
-#    NomTESCor1Pr      = cms.double(0.7)  # DecayMode==0
-#    NomTESCor1PrPi0   = cms.double(-0.2) # DecayMode==1
-#    NomTESCor3Pr      = cms.double(0.1)  # DecayMode==10
-#    NomTESCor3PrPi0   = cms.double(-0.1) # DecayMode==11
+#    NomTESUncDM0      = cms.double(0.8)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM1   = cms.double(0.8)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM10      = cms.double(0.9)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM11   = cms.double(1.0)  # in percent, up/down uncertainty of TES
+#    NomTESCorDM0      = cms.double(0.7)  # DecayMode==0
+#    NomTESCorDM1   = cms.double(-0.2) # DecayMode==1
+#    NomTESCorDM10      = cms.double(0.1)  # DecayMode==10
+#    NomTESCorDM11   = cms.double(-0.1) # DecayMode==11
 
 # 2018 data - MVAoldDM2017v2
 #if YEAR == 2018:
-#    NomTESUnc1Pr      = cms.double(1.1)  # in percent, up/down uncertainty of TES
-#    NomTESUnc1PrPi0   = cms.double(0.9)  # in percent, up/down uncertainty of TES
-#    NomTESUnc3Pr      = cms.double(0.8)  # in percent, up/down uncertainty of TES
-#    NomTESUnc3PrPi0   = --> Missing <--  # in percent, up/down uncertainty of TES
-#    NomTESCor1Pr      = cms.double(-1.3) # DecayMode==0
-#    NomTESCor1PrPi0   = cms.double(-0.5) # DecayMode==1
-#    NomTESCor3Pr      = cms.double(-1.2) # DecayMode==10
-#    NomTESCor3PrPi0   = --> Missing <--  # DecayMode==11
+#    NomTESUncDM0      = cms.double(1.1)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM1   = cms.double(0.9)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM10      = cms.double(0.8)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM11   = --> Missing <--  # in percent, up/down uncertainty of TES
+#    NomTESCorDM0      = cms.double(-1.3) # DecayMode==0
+#    NomTESCorDM1   = cms.double(-0.5) # DecayMode==1
+#    NomTESCorDM10      = cms.double(-1.2) # DecayMode==10
+#    NomTESCorDM11   = --> Missing <--  # DecayMode==11
 
 # 2016 data - DeepTau2017v2p1
-NomTESUnc1Pr      = cms.double(0.7)  # in percent, up/down uncertainty of TES
-NomTESUnc1PrPi0   = cms.double(0.3)  # in percent, up/down uncertainty of TES
-NomTESUnc3Pr      = cms.double(0.4)  # in percent, up/down uncertainty of TES
-NomTESUnc3PrPi0   = cms.double(0.6)  # in percent, up/down uncertainty of TES
-NomTESCor1Pr      = cms.double(-1.0) # DecayMode==0
-NomTESCor1PrPi0   = cms.double(-0.1) # DecayMode==1
-NomTESCor3Pr      = cms.double(0.0)  # DecayMode==10
-NomTESCor3PrPi0   = cms.double(2.6)  # DecayMode==11
-NominalEFakeESCor1Pr      = cms.double(-0.5) #DecayMode==0
-NominalEFakeESCor1PrPi0   = cms.double(6) #DecayMode==1
-NominalEFakeESUnc1Pr     = cms.double(0.) #DecayMode==0
-NominalEFakeESUnc1PrPi0  = cms.double(0.) #DecayMode==1
+NomTESUncDM0      = cms.double(0.7)  # in percent, up/down uncertainty of TES
+NomTESUncDM1      = cms.double(0.3)  # in percent, up/down uncertainty of TES
+NomTESUncDM10     = cms.double(0.4)  # in percent, up/down uncertainty of TES
+NomTESUncDM11     = cms.double(0.6)  # in percent, up/down uncertainty of TES
+NomTESCorDM0      = cms.double(-1.0) # DecayMode==0
+NomTESCorDM1      = cms.double(-0.1) # DecayMode==1
+NomTESCorDM10     = cms.double(0.0)  # DecayMode==10
+NomTESCorDM11     = cms.double(2.6)  # DecayMode==11
+
+#EES BARREL
+NomlEFakeESCorDM0B     = cms.double(0.679) #DecayMode==0
+NomEFakeESUncDM0BUp    = cms.double(0.806) #DecayMode==0
+NomEFakeESUncDM0BDown  = cms.double(0.982) #DecayMode==0
+NomEFakeESCorDM1B      = cms.double(3.389) #DecayMode==1
+NomEFakeESUncDM1BUp    = cms.double(1.168) #DecayMode==1
+NomEFakeESUncDM1BDown  = cms.double(2.475) #DecayMode==1
+#EES ENDCAP
+NomEFakeESCorDM0E      = cms.double(-3.5)   #DecayMode==0
+NomEFakeESUncDM0EUp    = cms.double(1.808)  #DecayMode==0
+NomEFakeESUncDM0EDown  = cms.double(1.102)  #DecayMode==0
+NomEFakeESCorDM1E      = cms.double(5.)      #DecayMode==1
+NomEFakeESUncDM1EUp    = cms.double(6.57)   #DecayMode==1
+NomEFakeESUncDM1EDown  = cms.double(5.694)  #DecayMode==1
+
 # 2017 data - DeepTau2017v2p1
 if YEAR == 2017:
-    NomTESUnc1Pr      = cms.double(0.7)  # in percent, up/down uncertainty of TES
-    NomTESUnc1PrPi0   = cms.double(0.3)  # in percent, up/down uncertainty of TES
-    NomTESUnc3Pr      = cms.double(0.5)  # in percent, up/down uncertainty of TES
-    NomTESUnc3PrPi0   = cms.double(0.6)  # in percent, up/down uncertainty of TES
-    NomTESCor1Pr      = cms.double(-0.7) # DecayMode==0
-    NomTESCor1PrPi0   = cms.double(-1.1) # DecayMode==1
-    NomTESCor3Pr      = cms.double(0.5)  # DecayMode==10
-    NomTESCor3PrPi0   = cms.double(1.7)  # DecayMode==1
-    NominalEFakeESCor1Pr      = cms.double(-1.8) #DecayMode==0
-    NominalEFakeESCor1PrPi0   = cms.double(1.8) #DecayMode==1
-    NominalEFakeESUnc1Pr     = cms.double(0.) #DecayMode==0
-    NominalEFakeESUnc1PrPi0  = cms.double(0.) #DecayMode==1
+    NomTESUncDM0      = cms.double(0.7)  # in percent, up/down uncertainty of TES
+    NomTESUncDM1      = cms.double(0.3)  # in percent, up/down uncertainty of TES
+    NomTESUncDM10     = cms.double(0.5)  # in percent, up/down uncertainty of TES
+    NomTESUncDM11     = cms.double(0.6)  # in percent, up/down uncertainty of TES
+    NomTESCorDM0      = cms.double(-0.7) # DecayMode==0
+    NomTESCorDM1      = cms.double(-1.1) # DecayMode==1
+    NomTESCorDM10     = cms.double(0.5)  # DecayMode==10
+    NomTESCorDM11     = cms.double(1.7)  # DecayMode==1
+
+    #EES BARREL
+    NomEFakeESCorDM0B      = cms.double(0.911) #DecayMode==0
+    NomEFakeESUncDM0BUp    = cms.double(1.343) #DecayMode==0
+    NomEFakeESUncDM0BDown  = cms.double(0.882) #DecayMode==0
+    NomEFakeESCorDM1B      = cms.double(1.154) #DecayMode==1
+    NomEFakeESUncDM1BUp    = cms.double(2.162) #DecayMode==1
+    NomEFakeESUncDM1BDown  = cms.double(0.973) #DecayMode==1
+    #EES ENDCAP
+    NomEFakeESCorDM0E      = cms.double(-2.604)   #DecayMode==0
+    NomEFakeESUncDM0EUp    = cms.double(2.249)    #DecayMode==0
+    NomEFakeESUncDM0EDown  = cms.double(1.43)     #DecayMode==0
+    NomEFakeESCorDM1E      = cms.double(1.5)    #DecayMode==1
+    NomEFakeESUncDM1EUp    = cms.double(6.461)      #DecayMode==1
+    NomEFakeESUncDM1EDown  = cms.double(4.969)    #DecayMode==1
 
 # 2018 data - DeepTau2017v2p1
 if YEAR == 2018:
-    NomTESUnc1Pr      = cms.double(0.8)  # in percent, up/down uncertainty of TES
-    NomTESUnc1PrPi0   = cms.double(0.3)  # in percent, up/down uncertainty of TES
-    NomTESUnc3Pr      = cms.double(0.4)  # in percent, up/down uncertainty of TES
-    NomTESUnc3PrPi0   = cms.double(1.0)  # in percent, up/down uncertainty of TES
-    NomTESCor1Pr      = cms.double(-1.6) # DecayMode==0
-    NomTESCor1PrPi0   = cms.double(0.8)  # DecayMode==1
-    NomTESCor3Pr      = cms.double(-0.9) # DecayMode==10
-    NomTESCor3PrPi0   = cms.double(1.3)  # DecayMode==11
-    NominalEFakeESCor1Pr      = cms.double(-3.2) #DecayMode==0
-    NominalEFakeESCor1PrPi0   = cms.double(2.6) #DecayMode==1
-    NominalEFakeESUnc1Pr     = cms.double(0.) #DecayMode==0
-    NominalEFakeESUnc1PrPi0  = cms.double(0.) #DecayMode==1
+    NomTESUncDM0          = cms.double(0.8)  # in percent, up/down uncertainty of TES
+    NomTESUncDM1          = cms.double(0.3)  # in percent, up/down uncertainty of TES
+    NomTESUncDM10         = cms.double(0.4)  # in percent, up/down uncertainty of TES
+    NomTESUncDM11         = cms.double(1.0)  # in percent, up/down uncertainty of TES
+    NomTESCorDM0          = cms.double(-1.6) # DecayMode==0
+    NomTESCorDM1          = cms.double(0.8)  # DecayMode==1
+    NomTESCorDM10         = cms.double(-0.9) # DecayMode==10
+    NomTESCorDM11         = cms.double(1.3)  # DecayMode==11
+
+    #EES BARREL
+    NomEFakeESCorDM0B      = cms.double(1.362)    #DecayMode==0
+    NomEFakeESUncDM0BUp    = cms.double(0.904)    #DecayMode==0
+    NomEFakeESUncDM0BDown  = cms.double(0.474)    #DecayMode==0
+    NomEFakeESCorDM1B      = cms.double(1.954)    #DecayMode==1
+    NomEFakeESUncDM1BUp    = cms.double(1.226)    #DecayMode==1
+    NomEFakeESUncDM1BDown  = cms.double(1.598)    #DecayMode==1
+    #EES ENDCAP
+    NomEFakeESCorDM0E      = cms.double(-3.097)   #DecayMode==0
+    NomEFakeESUncDM0EUp    = cms.double(3.404)    #DecayMode==0
+    NomEFakeESUncDM0EDown  = cms.double(1.25)     #DecayMode==0
+    NomEFakeESCorDM1E      = cms.double(-1.5)     #DecayMode==1
+    NomEFakeESUncDM1EUp    = cms.double(5.499)    #DecayMode==1
+    NomEFakeESUncDM1EDown  = cms.double(4.309)    #DecayMode==1
+
 
 process.softTaus = cms.EDProducer("TauFiller",
    src = cms.InputTag("bareTaus"),
@@ -450,18 +488,27 @@ process.softTaus = cms.EDProducer("TauFiller",
    cut = cms.string(TAUCUT),
    discriminator = cms.string(TAUDISCRIMINATOR),
 
-   NominalTESUncertainty1Pr         = NomTESUnc1Pr,
-   NominalTESUncertainty1PrPi0      = NomTESUnc1PrPi0,
-   NominalTESUncertainty3Pr         = NomTESUnc3Pr,
-   NominalTESUncertainty3PrPi0      = NomTESUnc3PrPi0,
-   NominalTESCorrection1Pr          = NomTESCor1Pr,
-   NominalTESCorrection1PrPi0       = NomTESCor1PrPi0,
-   NominalTESCorrection3Pr          = NomTESCor3Pr,
-   NominalTESCorrection3PrPi0       = NomTESCor3PrPi0,
-   NominalEFakeESCorrection1Pr       = NominalEFakeESCor1Pr,
-   NominalEFakeESCorrection1PrPi0    = NominalEFakeESCor1PrPi0,
-   NominalEFakeESUncertainty1Pr      = NominalEFakeESUnc1Pr, 
-   NominalEFakeESUncertainty1PrPi0   = NominalEFakeESUnc1PrPi0, 
+   NominalTESUncertaintyDM0         = NomTESUncDM0,
+   NominalTESUncertaintyDM1         = NomTESUncDM1,
+   NominalTESUncertaintyDM10        = NomTESUncDM10,
+   NominalTESUncertaintyDM11        = NomTESUncDM11,
+   NominalTESCorrectionDM0          = NomTESCorDM0,
+   NominalTESCorrectionDM1          = NomTESCorDM1,
+   NominalTESCorrectionDM10         = NomTESCorDM10,
+   NominalTESCorrectionDM11         = NomTESCorDM11,
+
+   NominalEFakeESCorrectionDM0B      = NomEFakeESCorDM0B,
+   NominalEFakeESUncertaintyDM0BUp   = NomEFakeESUncDM0BUp, 
+   NominalEFakeESUncertaintyDM0BDown = NomEFakeESUncDM0BDown, 
+   NominalEFakeESCorrectionDM1B      = NomEFakeESCorDM1B,
+   NominalEFakeESUncertaintyDM1BUp   = NomEFakeESUncDM1BUp, 
+   NominalEFakeESUncertaintyDM1BDown = NomEFakeESUncDM1BDown, 
+   NominalEFakeESCorrectionDM0E      = NomEFakeESCorDM0E,
+   NominalEFakeESUncertaintyDM0EUp   = NomEFakeESUncDM0EUp, 
+   NominalEFakeESUncertaintyDM0EDown = NomEFakeESUncDM0EDown, 
+   NominalEFakeESCorrectionDM1E      = NomEFakeESCorDM1E,
+   NominalEFakeESUncertaintyDM1EUp   = NomEFakeESUncDM1EUp, 
+   NominalEFakeESUncertaintyDM1EDown = NomEFakeESUncDM1EDown, 
 
    ApplyTESCentralCorr = cms.bool(APPLYTESCORRECTION),
    # ApplyTESUpDown = cms.bool(True if IsMC else False), # no shift computation when data

--- a/README.md
+++ b/README.md
@@ -378,9 +378,9 @@ scram b -j 8
 ### Instructions for 102X
 
 ```
-export SCRAM_ARCH=slc7_amd64_gcc700 # needed at LLR
-cmsrel CMSSW_10_2_16_UL
-cd CMSSW_10_2_16_UL/src
+export SCRAM_ARCH=slc7_amd64_gcc820 # needed at LLR
+cmsrel CMSSW_10_2_18
+cd CMSSW_10_2_18/src
 cmsenv
 
 # MVA EleID Fall 2018

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ scram b -j 8
 ### Instructions for 102X
 
 ```
+export SCRAM_ARCH=slc7_amd64_gcc700 # needed at LLR
 cmsrel CMSSW_10_2_16_UL
 cd CMSSW_10_2_16_UL/src
 cmsenv


### PR DESCRIPTION
Used https://indico.cern.ch/event/868279/contributions/3665970/attachments/1959265/3267731/FES_9Dec_explained.pdf

* some changes in the naming to make the shifts in the config more readable
* split E/B
* asymmetric uncertainties on e->tauh ES correction
* to be tested