### PR TITLE
Changes for Feb2020 Sync

### DIFF
--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -72,16 +72,16 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 if IsMC:
   if YEAR == 2016:
-    process.GlobalTag.globaltag = '94X_mcRun2_asymptotic_v3'        # 2016 MC
+    process.GlobalTag.globaltag = '102X_mcRun2_asymptotic_v7'        # 2016 MC
   if YEAR == 2017:
-    process.GlobalTag.globaltag = '94X_mc2017_realistic_v17'        # 2017 MC
+    process.GlobalTag.globaltag = '102X_mc2017_realistic_v7'        # 2017 MC
   if YEAR == 2018:
     process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v20'  # 2018 MC
 else :
   if YEAR == 2016:
-    process.GlobalTag.globaltag = '94X_dataRun2_v10'                # 2016 Data
+    process.GlobalTag.globaltag = '102X_dataRun2_v12'                # 2016 Data
   if YEAR == 2017:
-    process.GlobalTag.globaltag = '94X_dataRun2_v11'                # 2017 Data
+    process.GlobalTag.globaltag = '102X_dataRun2_v12'                # 2017 Data
   if YEAR == 2018:
     if PERIOD=="D":
         process.GlobalTag.globaltag = '102X_dataRun2_Prompt_v15'    # 2018D Data

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -742,7 +742,7 @@ else:
             872421955,872421567,872437184,872421951,
             872421694,872437056,872437057,872437313])
 
-    # In 2016 not problem --> pass empty list
+    # In 2016 no problem --> pass empty list
     if YEAR == 2016:
         baddetEcallist = cms.vuint32([])
 
@@ -755,8 +755,6 @@ else:
         debug = cms.bool(False)
         )
 
-
-import pdb; pdb.set_trace()
 
 ## ----------------------------------------------------------------------
 ## Z-recoil correction

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -337,8 +337,7 @@ process.cleanTaus = cms.EDProducer("PATTauCleaner",
         finalCut = cms.string(' '),
 )
 
-# TES corrections: https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauIDRecommendationForRun2#Tau_energy_scale_for_MVA_tau_id
-# for DeepTau: https://indico.cern.ch/event/864131/contributions/3644021/attachments/1946837/3230164/Izaak_TauPOG_TauES_20191118.pdf
+# TES corrections: https://indico.cern.ch/event/887196/contributions/3743090/attachments/1984772/3306737/TauPOG_TES_20200210.pdf
 
 # EES corrections: https://indico.cern.ch/event/868279/contributions/3665970/attachments/1959265/3267731/FES_9Dec_explained.pdf
 
@@ -346,46 +345,46 @@ process.cleanTaus = cms.EDProducer("PATTauCleaner",
 APPLYTESCORRECTION = APPLYTESCORRECTION if IsMC else False # always false if data
 
 # 2016 data - MVAoldDM2017v2
-#NomTESUncDM0      = cms.double(1.0)  # in percent, up/down uncertainty of TES
+#NomTESUncDM0   = cms.double(1.0)  # in percent, up/down uncertainty of TES
 #NomTESUncDM1   = cms.double(0.9)  # in percent, up/down uncertainty of TES
-#NomTESUncDM10      = cms.double(1.1)  # in percent, up/down uncertainty of TES
-#NomTESUncDM11   = --> Missing <--  # in percent, up/down uncertainty of TES
-#NomTESCorDM0      = cms.double(-0.6) # DecayMode==0
+#NomTESUncDM10  = cms.double(1.1)  # in percent, up/down uncertainty of TES
+#NomTESUncDM11  = --> Missing <--  # in percent, up/down uncertainty of TES
+#NomTESCorDM0   = cms.double(-0.6) # DecayMode==0
 #NomTESCorDM1   = cms.double(-0.5) # DecayMode==1
-#NomTESCorDM10      = cms.double(0.0)  # DecayMode==10
-#NomTESCorDM11   = --> Missing <--  # DecayMode==11
+#NomTESCorDM10  = cms.double(0.0)  # DecayMode==10
+#NomTESCorDM11  = --> Missing <--  # DecayMode==11
 
 # 2017 data - MVAoldDM2017v2
 #if YEAR == 2017:
-#    NomTESUncDM0      = cms.double(0.8)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM0   = cms.double(0.8)  # in percent, up/down uncertainty of TES
 #    NomTESUncDM1   = cms.double(0.8)  # in percent, up/down uncertainty of TES
-#    NomTESUncDM10      = cms.double(0.9)  # in percent, up/down uncertainty of TES
-#    NomTESUncDM11   = cms.double(1.0)  # in percent, up/down uncertainty of TES
-#    NomTESCorDM0      = cms.double(0.7)  # DecayMode==0
+#    NomTESUncDM10  = cms.double(0.9)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM11  = cms.double(1.0)  # in percent, up/down uncertainty of TES
+#    NomTESCorDM0   = cms.double(0.7)  # DecayMode==0
 #    NomTESCorDM1   = cms.double(-0.2) # DecayMode==1
-#    NomTESCorDM10      = cms.double(0.1)  # DecayMode==10
-#    NomTESCorDM11   = cms.double(-0.1) # DecayMode==11
+#    NomTESCorDM10  = cms.double(0.1)  # DecayMode==10
+#    NomTESCorDM11  = cms.double(-0.1) # DecayMode==11
 
 # 2018 data - MVAoldDM2017v2
 #if YEAR == 2018:
-#    NomTESUncDM0      = cms.double(1.1)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM0   = cms.double(1.1)  # in percent, up/down uncertainty of TES
 #    NomTESUncDM1   = cms.double(0.9)  # in percent, up/down uncertainty of TES
-#    NomTESUncDM10      = cms.double(0.8)  # in percent, up/down uncertainty of TES
-#    NomTESUncDM11   = --> Missing <--  # in percent, up/down uncertainty of TES
-#    NomTESCorDM0      = cms.double(-1.3) # DecayMode==0
+#    NomTESUncDM10  = cms.double(0.8)  # in percent, up/down uncertainty of TES
+#    NomTESUncDM11  = --> Missing <--  # in percent, up/down uncertainty of TES
+#    NomTESCorDM0   = cms.double(-1.3) # DecayMode==0
 #    NomTESCorDM1   = cms.double(-0.5) # DecayMode==1
-#    NomTESCorDM10      = cms.double(-1.2) # DecayMode==10
-#    NomTESCorDM11   = --> Missing <--  # DecayMode==11
+#    NomTESCorDM10  = cms.double(-1.2) # DecayMode==10
+#    NomTESCorDM11  = --> Missing <--  # DecayMode==11
 
 # 2016 data - DeepTau2017v2p1
-NomTESUncDM0      = cms.double(0.7)  # in percent, up/down uncertainty of TES
-NomTESUncDM1      = cms.double(0.3)  # in percent, up/down uncertainty of TES
-NomTESUncDM10     = cms.double(0.4)  # in percent, up/down uncertainty of TES
-NomTESUncDM11     = cms.double(0.6)  # in percent, up/down uncertainty of TES
-NomTESCorDM0      = cms.double(-1.0) # DecayMode==0
+NomTESUncDM0      = cms.double(0.8)  # in percent, up/down uncertainty of TES
+NomTESUncDM1      = cms.double(0.6)  # in percent, up/down uncertainty of TES
+NomTESUncDM10     = cms.double(0.8)  # in percent, up/down uncertainty of TES
+NomTESUncDM11     = cms.double(1.1)  # in percent, up/down uncertainty of TES
+NomTESCorDM0      = cms.double(-0.9) # DecayMode==0
 NomTESCorDM1      = cms.double(-0.1) # DecayMode==1
-NomTESCorDM10     = cms.double(0.0)  # DecayMode==10
-NomTESCorDM11     = cms.double(2.6)  # DecayMode==11
+NomTESCorDM10     = cms.double(0.3)  # DecayMode==10
+NomTESCorDM11     = cms.double(-0.2) # DecayMode==11
 
 #EES BARREL
 NomEFakeESCorDM0B     = cms.double(0.679) #DecayMode==0
@@ -394,7 +393,6 @@ NomEFakeESUncDM0BDown  = cms.double(0.982) #DecayMode==0
 NomEFakeESCorDM1B      = cms.double(3.389) #DecayMode==1
 NomEFakeESUncDM1BUp    = cms.double(1.168) #DecayMode==1
 NomEFakeESUncDM1BDown  = cms.double(2.475) #DecayMode==1
-
 #EES ENDCAP
 NomEFakeESCorDM0E      = cms.double(-3.5)   #DecayMode==0
 NomEFakeESUncDM0EUp    = cms.double(1.808)  #DecayMode==0
@@ -405,14 +403,14 @@ NomEFakeESUncDM1EDown  = cms.double(5.694)  #DecayMode==1
 
 # 2017 data - DeepTau2017v2p1
 if YEAR == 2017:
-    NomTESUncDM0      = cms.double(0.7)  # in percent, up/down uncertainty of TES
-    NomTESUncDM1      = cms.double(0.3)  # in percent, up/down uncertainty of TES
-    NomTESUncDM10     = cms.double(0.5)  # in percent, up/down uncertainty of TES
-    NomTESUncDM11     = cms.double(0.6)  # in percent, up/down uncertainty of TES
-    NomTESCorDM0      = cms.double(-0.7) # DecayMode==0
-    NomTESCorDM1      = cms.double(-1.1) # DecayMode==1
-    NomTESCorDM10     = cms.double(0.5)  # DecayMode==10
-    NomTESCorDM11     = cms.double(1.7)  # DecayMode==1
+    NomTESUncDM0      = cms.double(1.0)  # in percent, up/down uncertainty of TES
+    NomTESUncDM1      = cms.double(0.6)  # in percent, up/down uncertainty of TES
+    NomTESUncDM10     = cms.double(0.7)  # in percent, up/down uncertainty of TES
+    NomTESUncDM11     = cms.double(1.4)  # in percent, up/down uncertainty of TES
+    NomTESCorDM0      = cms.double(0.4)  # DecayMode==0
+    NomTESCorDM1      = cms.double(0.2)  # DecayMode==1
+    NomTESCorDM10     = cms.double(0.1)  # DecayMode==10
+    NomTESCorDM11     = cms.double(-1.3) # DecayMode==1
 
     #EES BARREL
     NomEFakeESCorDM0B      = cms.double(0.911) #DecayMode==0
@@ -431,14 +429,14 @@ if YEAR == 2017:
 
 # 2018 data - DeepTau2017v2p1
 if YEAR == 2018:
-    NomTESUncDM0          = cms.double(0.8)  # in percent, up/down uncertainty of TES
-    NomTESUncDM1          = cms.double(0.3)  # in percent, up/down uncertainty of TES
-    NomTESUncDM10         = cms.double(0.4)  # in percent, up/down uncertainty of TES
-    NomTESUncDM11         = cms.double(1.0)  # in percent, up/down uncertainty of TES
+    NomTESUncDM0          = cms.double(0.9)  # in percent, up/down uncertainty of TES
+    NomTESUncDM1          = cms.double(0.5)  # in percent, up/down uncertainty of TES
+    NomTESUncDM10         = cms.double(0.7)  # in percent, up/down uncertainty of TES
+    NomTESUncDM11         = cms.double(1.2)  # in percent, up/down uncertainty of TES
     NomTESCorDM0          = cms.double(-1.6) # DecayMode==0
-    NomTESCorDM1          = cms.double(0.8)  # DecayMode==1
-    NomTESCorDM10         = cms.double(-0.9) # DecayMode==10
-    NomTESCorDM11         = cms.double(1.3)  # DecayMode==11
+    NomTESCorDM1          = cms.double(-0.5) # DecayMode==1
+    NomTESCorDM10         = cms.double(-1.2) # DecayMode==10
+    NomTESCorDM11         = cms.double(-0.4) # DecayMode==11
 
     #EES BARREL
     NomEFakeESCorDM0B      = cms.double(1.362)    #DecayMode==0

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -568,7 +568,7 @@ btagVector = []
 if YEAR == 2018:
     btagVector.append('None')
 
-if YEAR == 2017 or YEAR == 2016:
+if YEAR == 2017:
     btagVector2017 = [
         'pfDeepFlavourJetTags:probb',
         'pfDeepFlavourJetTags:probbb',

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -534,11 +534,21 @@ process.softLeptons = cms.EDProducer("CandViewMerger",
 
 # # add latest pileup jet ID
 process.load("RecoJets.JetProducers.PileupJetID_cfi")
+from RecoJets.JetProducers.PileupJetID_cfi import _chsalgos_81x, _chsalgos_94x, _chsalgos_102x
+
+if YEAR == 2016:
+    PUalgo = _chsalgos_81x
+if YEAR == 2017:
+    PUalgo = _chsalgos_94x
+if YEAR == 2018:
+    PUalgo = _chsalgos_102x
+
 process.pileupJetIdUpdated = process.pileupJetId.clone(
    jets = cms.InputTag("slimmedJets"),
    inputIsCorrected = True,
    applyJec = True,
-   vertexes = cms.InputTag("offlineSlimmedPrimaryVertices")
+   vertexes = cms.InputTag("offlineSlimmedPrimaryVertices"),
+   algos = PUalgo
 )
 #print process.pileupJetIdUpdated.dumpConfig()
 

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -401,6 +401,8 @@ NomEFakeESCorDM1E      = cms.double(5.)      #DecayMode==1
 NomEFakeESUncDM1EUp    = cms.double(6.57)   #DecayMode==1
 NomEFakeESUncDM1EDown  = cms.double(5.694)  #DecayMode==1
 
+TESyear = "2016Legacy"
+
 # 2017 data - DeepTau2017v2p1
 if YEAR == 2017:
     NomTESUncDM0      = cms.double(1.0)  # in percent, up/down uncertainty of TES
@@ -426,6 +428,8 @@ if YEAR == 2017:
     NomEFakeESCorDM1E      = cms.double(1.5)    #DecayMode==1
     NomEFakeESUncDM1EUp    = cms.double(6.461)      #DecayMode==1
     NomEFakeESUncDM1EDown  = cms.double(4.969)    #DecayMode==1
+
+    TESyear = "2017ReReco"
 
 # 2018 data - DeepTau2017v2p1
 if YEAR == 2018:
@@ -453,6 +457,7 @@ if YEAR == 2018:
     NomEFakeESUncDM1EUp    = cms.double(5.499)    #DecayMode==1
     NomEFakeESUncDM1EDown  = cms.double(4.309)    #DecayMode==1
 
+    TESyear = "2018ReReco"
 
 process.softTaus = cms.EDProducer("TauFiller",
    src = cms.InputTag("bareTaus"),
@@ -487,7 +492,9 @@ process.softTaus = cms.EDProducer("TauFiller",
    # ApplyTESUpDown = cms.bool(True if IsMC else False), # no shift computation when data
    flags = cms.PSet(
         isGood = cms.string("")
-        )
+        ),
+
+   year = cms.string(TESyear)
    )
 
 process.taus=cms.Sequence(process.rerunMvaIsolationSequence + process.slimmedTausNewID + process.bareTaus + process.softTaus)

--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -84,77 +84,25 @@ else :
 ### ----------------------------------------------------------------------
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-    # '/store/mc/RunIISpring16MiniAODv2/SMS-TChiHH_HToBB_HToTauTau_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16Fast_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/00000/B8A61C30-5E12-E711-87BB-FA163E939724.root',
-    #'/store/mc/RunIISpring16MiniAODv2/SMS-TChiHH_HToBB_HToTauTau_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16Fast_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/00000/0264645E-5E12-E711-889B-E41D2D08DD10.root',
-    # '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/60000/4CBBCFDF-F8C6-E611-A5C2-6CC2173BBD40.root',
-    # '/store/mc/RunIISummer16MiniAODv2/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/00000/AC8AA010-88BB-E611-9974-FA163E1B885B.root',
-    #'/store/mc/RunIISummer16MiniAODv2/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/80000/80EA9B8A-A1C1-E611-A107-20CF3027A61A.root',
-    #'/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/120000/E6D5D5EB-8299-E611-83D1-FA163EB4F61D.root',
-    ####'/store/data/Run2016C/SingleMuon/MINIAOD/23Sep2016-v1/80000/F8F49A79-BE89-E611-A029-008CFA1974E4.root'
-    #'/store/data/Run2016B/SingleMuon/MINIAOD/PromptReco-v2/000/273/150/00000/34A57FB8-D819-E611-B0A4-02163E0144EE.root', #80X data
-    # '/store/mc/RunIISpring16MiniAODv1/GluGluToBulkGravitonToHHTo2B2Tau_M-400_narrow_13TeV-madgraph/MINIAODSIM/PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_v3_ext1-v1/30000/06E22BEA-9F10-E611-9862-1CB72C0A3A5D.root', #80X MC
-    # '/store/mc/RunIIFall15MiniAODv2/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/50000/12184969-3DB8-E511-879B-001E67504A65.root', #76X MC
-    
-    # 2017 Data
-    # B_v1
-    #'/store/data/Run2017B/SingleMuon/MINIAOD/PromptReco-v1/000/297/046/00000/32AC3177-7A56-E711-BE34-02163E019D73.root',
-    #'/store/data/Run2017B/SingleElectron/MINIAOD/PromptReco-v1/000/297/046/00000/02CBE6D1-4456-E711-82F5-02163E019D97.root', # 5000   evts
-    #'/store/data/Run2017B/SingleElectron/MINIAOD/PromptReco-v1/000/297/050/00000/166F7BB0-3C56-E711-BD8B-02163E0145C5.root',  # 147000 evts
-    #'/store/data/Run2017B/Tau/MINIAOD/PromptReco-v1/000/297/046/00000/B600F102-4856-E711-839A-02163E01411B.root',
-    # C_v3
-    #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/0AC61DCE-457E-E711-9CAE-02163E014217.root',
-    # root://cms-xrd-global.cern.ch//store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/240BA088-597E-E711-ADE4-02163E019C30.root
-    #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/240BA088-597E-E711-ADE4-02163E019C30.root',
-    #'/store/data/Run2017C/SingleMuon/MINIAOD/PromptReco-v3/000/300/742/00000/425DFEF6-5D7E-E711-8F2F-02163E01A1DD.root',
-    
-    # MC 2017 - GT:92X_upgrade2017_realistic_v10
-    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/0080A67C-FBA4-E711-A8FE-00259029E84C.root',
-    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/0678C84B-F49E-E711-B561-A0369FC51AD4.root',
-    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/NZSFlatPU28to62_HIG07_92X_upgrade2017_realistic_v10-v1/70000/088CC59F-F39C-E711-8124-549F35AF44E3.root',
-    
-    # 2017 embedded samples - GT: 92X_dataRun2_Prompt_v4
-    #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_0.root',    # 688 evts
-    #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_100.root',  # 715 evts
-    #'/store/user/pahrens/gc_storage/MuTau_data_2017_CMSSW923p2_freiburg_v7/TauEmbedding_MuTau_data_2017_CMSSW923p2_Run2017B/merged/1/merged_1000.root', # 657 evts
-    
-    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10-v2/50000/02098EBB-029C-E711-8FED-441EA1714E4C.root'
-    #'/store/mc/RunIISummer17MiniAOD/VBFHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10-v2/50000/2A50557C-829D-E711-9331-10983627C3CE.root',
-    
-    # Samples for SyncFeb2018
-    # Signal
-    #'/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/128F2EAF-6905-E811-810E-44A842BECCD8.root',
-    #'/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/F89C5A80-6905-E811-9A3F-FA163ED3ED08.root',
-    #'/store/mc/RunIIFall17MiniAOD/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/34715D6D-6905-E811-9843-44A842CFD5BE.root',
-    # miniAOD_v2
-    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/1CA54262-F442-E811-8262-0CC47A4D7694.root',
-    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/5ED78A31-7243-E811-8053-484D7E8DF09F.root',
-    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/8CDFDFC6-C542-E811-9360-848F69FBC12A.root',
-    #'/store/mc/RunIIFall17MiniAODv2/GluGluToBulkGravitonToHHTo2B2Tau_M-450_narrow_13TeV-madgraph/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/A4C07038-AC42-E811-8A74-1418776375C9.root',
-    #'file:/afs/cern.ch/work/f/fbrivio/Hhh_1718/production/CMSSW_9_4_6_patch1/src/LLRHiggsTauTau/NtupleProducer/inputFiles/Graviton450_1.root',
-    #'file:/afs/cern.ch/work/f/fbrivio/Hhh_1718/production/CMSSW_9_4_6_patch1/src/LLRHiggsTauTau/NtupleProducer/inputFiles/Graviton450_2.root',
-    #'file:/afs/cern.ch/work/f/fbrivio/Hhh_1718/production/CMSSW_9_4_6_patch1/src/LLRHiggsTauTau/NtupleProducer/inputFiles/Graviton450_3.root',
-    #'file:/afs/cern.ch/work/f/fbrivio/Hhh_1718/production/CMSSW_9_4_6_patch1/src/LLRHiggsTauTau/NtupleProducer/inputFiles/Graviton450_4.root',
 
-    # Data
-    #'/store/data/Run2017B/Tau/MINIAOD/17Nov2017-v1/40000/02D49C45-F8DD-E711-9ACC-001E675043AD.root',
-    #'/store/data/Run2017B/SingleMuon/MINIAOD/31Mar2018-v1/100000/001642F1-6638-E811-B4FA-0025905B857A.root',
-    # miniAOD_v2
-    #'/store/data/Run2017B/Tau/MINIAOD/31Mar2018-v1/00000/040B1CD3-9437-E811-8D93-A4BF01158FE0.root',
-    #'file:/afs/cern.ch/work/f/fbrivio/Hhh_1718/production/CMSSW_9_4_6_patch1/src/LLRHiggsTauTau/NtupleProducer/inputFiles/TauB.root'
-    #'/store/data/Run2017F/Tau/MINIAOD/31Mar2018-v1/00000/0089E8C0-1A37-E811-9E5C-008CFAC93D18.root',
-    #'file:/afs/cern.ch/work/f/fbrivio/Hhh_1718/production/CMSSW_9_4_6_patch1/src/LLRHiggsTauTau/NtupleProducer/inputFiles/TauF.root'
+    # - Sync files -
+    # Legacy 2016
+    #'/store/data/Run2016H/SingleElectron/MINIAOD/17Jul2018-v1/00000/0026BF69-A58A-E811-BBA8-1866DA87AB31.root'
+    #'/store/data/Run2016F/SingleMuon/MINIAOD/17Jul2018-v1/00000/002F631B-E98D-E811-A8FF-1CB72C1B64E6.root'
+    #'/store/data/Run2016C/Tau/MINIAOD/17Jul2018-v1/40000/FC60B37F-468A-E811-8C7B-0CC47A7C3424.root'
+    #'/store/mc/RunIISummer16MiniAODv3/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_94X_mcRun2_asymptotic_v3_ext2-v2/270000/EC774BCF-16E9-E811-B699-AC1F6B0DE2F4.root'
 
-    # TT Fully Hadronic
-    #'/store/mc/RunIIFall17MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/047A883D-9618-E811-B3FB-7CD30AD09FDC.root',
-    #'/store/mc/RunIIFall17MiniAODv2/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/20000/CA2359BE-6442-E811-A7C5-9CB654AEAE02.root'
-    # miniAOD_v2
-    #'/store/mc/RunIIFall17MiniAODv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/00000/0031EAB0-8442-E811-84DF-0025901AFB36.root',
-    #'file:/afs/cern.ch/work/f/fbrivio/Hhh_1718/production/CMSSW_9_4_6_patch1/src/LLRHiggsTauTau/NtupleProducer/inputFiles/TT.root',
+    # Legacy 2017
+    #'/store/data/Run2017D/SingleElectron/MINIAOD/31Mar2018-v1/90000/FEFBCFEA-5939-E811-99DA-0025905B85D6.root'
+    #'/store/data/Run2017F/SingleMuon/MINIAOD/31Mar2018-v1/80004/EEC206A7-5737-E811-8E0A-0CC47A2B0388.root'
+    #'/store/data/Run2017C/Tau/MINIAOD/31Mar2018-v1/90000/FE83BD44-CD37-E811-8731-842B2B180922.root'
+    #'/store/mc/RunIIFall17MiniAODv2/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/20000/0056F0F4-4F44-E811-B415-FA163E5B5253.root'
 
-    # DY 2 Jets
-    #'/store/mc/RunIIFall17MiniAODv2/DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/810000/BAE0A78F-7366-E811-B871-A0369FD20D18.root'
-
-    '/store/mc/RunIIAutumn18MiniAOD/GluGluToHHTo2B2Tau_node_2_TuneCP5_PSWeights_13TeV-madgraph-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/70000/F0801D64-DDFF-004A-B935-120B8090F5B8.root',
+    # Legacy 2018
+    #'/store/data/Run2018D/EGamma/MINIAOD/22Jan2019-v2/110000/2FD9167C-A197-E749-908D-3809F7B83A23.root'
+    #'/store/data/Run2018D/SingleMuon/MINIAOD/22Jan2019-v2/110000/0011A0F3-23A3-D444-AD4D-2A2FFAE23796.root'
+    #'/store/data/Run2018D/Tau/MINIAOD/PromptReco-v2/000/320/497/00000/584D46DF-5F95-E811-9646-FA163E293146.root'
+    #'/store/mc/RunIIAutumn18MiniAOD/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/120000/B3F93EA2-04C6-E04E-96AF-CB8FAF67E6BA.root'
 
     )
 )
@@ -180,7 +128,7 @@ if not IsMC:
 ## Output file
 ##
 process.TFileService=cms.Service('TFileService',fileName=cms.string('HTauTauAnalysis.root'))
-
+#process.TFileService=cms.Service('TFileService',fileName=cms.string('refFiles/Mu16_sync.root'))
 
 if DO_ENRICHED:
     process.out = cms.OutputModule("PoolOutputModule",

--- a/README.md
+++ b/README.md
@@ -378,9 +378,13 @@ scram b -j 8
 ### Instructions for 102X
 
 ```
-export SCRAM_ARCH=slc7_amd64_gcc820 # needed at LLR
-cmsrel CMSSW_10_2_18
-cd CMSSW_10_2_18/src
+## IMPORTANT ##
+# Make sure your are on SLC6 (ssh lxplus6.cern.ch)
+# and the architecture is slc6_amd64_gcc700
+# (you can set the architecture with: export SCRAM_ARCH=slc6_amd64_gcc700 )
+
+cmsrel CMSSW_10_2_20
+cd CMSSW_10_2_20/src
 cmsenv
 
 git cms-init
@@ -393,7 +397,7 @@ git cms-addpkg RecoJets/JetProducers
 git clone -b 94X_weights_DYJets_inc_v2 git@github.com:cms-jet/PUjetID.git PUJetIDweights/
 cp PUJetIDweights/weights/pileupJetId_{94,102}X_Eta* $CMSSW_BASE/src/RecoJets/JetProducers/data/
 rm -rf PUJetIDweights/
-git cms-merge-topic -u alefisico:PUID_102X
+git cms-merge-topic alefisico:PUID_102X
 
 # Z-recoil corrections
 git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/RecoilCorrections

--- a/README.md
+++ b/README.md
@@ -431,6 +431,9 @@ git cms-addpkg RecoMET/METFilters
 git clone https://github.com/SVfit/ClassicSVfit TauAnalysis/ClassicSVfit -b release_2018Mar20
 git clone https://github.com/svfit/SVfitTF TauAnalysis/SVfitTF
 
+#Add TauPOG corrections (TES and EES)
+git clone https://github.com/cms-tau-pog/TauIDSFs TauPOG/TauIDSFs
+
 #Add DeepTau code from Tau POG repository (note "-u" option preventing checkout of unnecessary stuff)
 git cms-merge-topic -u cms-tau-pog:CMSSW_10_2_X_tau-pog_DeepTau2017v2p1_nanoAOD
 

--- a/README.md
+++ b/README.md
@@ -383,9 +383,17 @@ cmsrel CMSSW_10_2_18
 cd CMSSW_10_2_18/src
 cmsenv
 
-# MVA EleID Fall 2018
 git cms-init
+
+# MVA EleID Fall 2018
 git cms-merge-topic cms-egamma:EgammaPostRecoTools  #if you want the V2 IDs, otherwise skip
+
+# PU jet ID
+git cms-addpkg RecoJets/JetProducers
+git clone -b 94X_weights_DYJets_inc_v2 git@github.com:cms-jet/PUjetID.git PUJetIDweights/
+cp PUJetIDweights/weights/pileupJetId_{94,102}X_Eta* $CMSSW_BASE/src/RecoJets/JetProducers/data/
+rm -rf PUJetIDweights/
+git cms-merge-topic -u alefisico:PUID_102X
 
 # Z-recoil corrections
 git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/RecoilCorrections


### PR DESCRIPTION
- Global Tags from: https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVAnalysisSummaryTable
- Different MET corrections for 2016, 2017 and 2018
-   Rerun deepFlavor for 2016 and 2017: https://twiki.cern.ch/twiki/bin/view/CMS/DeepJet#102X_installation_recipe
- Rerun deepCSV for 2016
- TES from slide 47 of: https://indico.cern.ch/event/887196/contributions/3743090/attachments/1984772/3306737/TauPOG_TES_20200210.pdf
