### PR TITLE
additional single-e trigger in 2017

### DIFF
--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -58,6 +58,19 @@ HLTLIST = cms.VPSet(
         pt1 = cms.double(38),
         pt2 = cms.double(-999)
         ),
+### emulated HLT_Ele32_WPTight_Gsf_v for Data// HLT_Ele32_WPTight_Gsf_v was online only from Run2017C
+    cms.PSet (
+        HLT = cms.string("HLT_Ele32_WPTight_Gsf_L1DoubleEG_v"),
+        path1 = cms.vstring ("hltEle32L1DoubleEGWPTightGsfTrackIsoFilter","hltEGL1SingleEGOrFilter"),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(11),
+        leg2 = cms.int32(999),
+        pt1 = cms.double(35),
+        pt2 = cms.double(-999)
+        ),
+
 ### === mu tauh triggers - OK
     cms.PSet (
         HLT = cms.string("HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1_v"),


### PR DESCRIPTION
The HLT_Ele32_WPTight_Gsf_v trigger was not active for the whole 2017 datataking; it is by construction a strict subset of the HLT_Ele32_WPTight_Gsf_L1DoubleEG_v trigger, which was online for the whole 2017 datataking and can be manipulated to obtain HLT_Ele32_WPTight_Gsf_v  ([EgHLT twiki](https://twiki.cern.ch/twiki/bin/view/CMS/EgHLTRunIISummary#2017)) 

* modified version of HLT_Ele32_WPTight_Gsf_L1DoubleEG_v added in the trigger list. It has hltEGL1SingleEGOrFilter applied, which makes it by construction equivalent to HLT_Ele32_WPTight_Gsf_v ([Eg 2017 twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/Egamma2017DataRecommendations#Single_Electron_Triggers))
* **in data**, the modified HLT_Ele32_WPTight_Gsf_L1DoubleEG_v path needs to be used 
* **in MC**, the modified HLT_Ele32_WPTight_Gsf_L1DoubleEG_v path and the original HLT_Ele32_WPTight_Gsf_v path are equivalent