### PR TITLE
ClassicSVfitInterface update

### DIFF
--- a/NtupleProducer/plugins/ClassicSVfitInterface.cc
+++ b/NtupleProducer/plugins/ClassicSVfitInterface.cc
@@ -1138,7 +1138,7 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVLooseIsolationMVArun2v1DBoldDMwLT") == 1);
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseIsolationMVArun2017v2DBoldDMwLT2017") == 1); //FRA 2017
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
-    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseDeepTau2017v2p1VSjet") == 1);
+    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
 
     if (!iso1 || !iso2)
       return false;
@@ -1166,7 +1166,7 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVLooseIsolationMVArun2v1DBoldDMwLT") == 1);
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseIsolationMVArun2017v2DBoldDMwLT2017") == 1); //FRA 2017
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
-    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseDeepTau2017v2p1VSjet") == 1);
+    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
 
     if (!iso1 || !iso2)
       return false;
@@ -1199,8 +1199,8 @@ bool ClassicSVfitInterface::IsInteresting (const reco::Candidate *l1, const reco
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseIsolationMVArun2017v2DBoldDMwLT2017") == 1); //FRA 2017
     //bool iso1 = (userdatahelpers::getUserInt(l1,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
     //bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
-    bool iso1 = (userdatahelpers::getUserInt(l1,"byVVLooseDeepTau2017v2p1VSjet") == 1);
-    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVLooseDeepTau2017v2p1VSjet") == 1);
+    bool iso1 = (userdatahelpers::getUserInt(l1,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
+    bool iso2 = (userdatahelpers::getUserInt(l2,"byVVVLooseDeepTau2017v2p1VSjet") == 1);
 
     if (!iso1 || !iso2)
       return false;


### PR DESCRIPTION
Since in KLUB we require that tauh pass the `byVVVLooseDeepTau2017v2p1VSjet` WP of deepTau discriminator, we need to compute SVfit quantities also for pairs containing these tauhs
(i.e. the selection in function `ClassicSVfitInterface::IsInteresting` is loosened)
