### PR TITLE
Last changes after sync Feb2020

### DIFF
--- a/NtupleProducer/test/analyzer.py
+++ b/NtupleProducer/test/analyzer.py
@@ -49,7 +49,7 @@ TAUDISCRIMINATOR="byIsolationMVA3oldDMwoLTraw"
 PVERTEXCUT="!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2" #cut on good primary vertexes
 MUCUT="isLooseMuon && pt>10"#"isLooseMuon && pt>5"
 ELECUT="pt>10"#"pt>7"#"gsfTracsk.hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS)<=1 && pt>10"
-TAUCUT="pt>18"#"tauID('byCombinedIsolationDeltaBetaCorrRaw3Hits') < 1000.0 && pt>18" #miniAOD tau from hpsPFTauProducer have pt>18 and decaymodefinding ID
+TAUCUT="pt>15"#"tauID('byCombinedIsolationDeltaBetaCorrRaw3Hits') < 1000.0 && pt>18" #miniAOD tau from hpsPFTauProducer have pt>18 and decaymodefinding ID
 JETCUT="pt>0" # was 10, is now 0 to save all the jets and be able to copute JEC MET in KLUB
 LLCUT="mass>-99999"
 BCUT="pt>5"

--- a/README.md
+++ b/README.md
@@ -428,10 +428,8 @@ cd -
 git cms-addpkg RecoMET/METFilters
 
 # SVfit
-git clone https://github.com/SVfit/ClassicSVfit TauAnalysis/ClassicSVfit -b release_2018Mar20
+git clone https://github.com/LLRCMS/ClassicSVfit.git TauAnalysis/ClassicSVfit -b bbtautau_LegacyRun2
 git clone https://github.com/svfit/SVfitTF TauAnalysis/SVfitTF
-# In order to avoid memory leaking and speed up the processing
-# uncomment lines 332-335 in TauAnalysis/ClassicSVfit/src/svFitHistogramAdapter.cc
 
 #Add TauPOG corrections (TES and EES)
 git clone https://github.com/cms-tau-pog/TauIDSFs TauPOG/TauIDSFs


### PR DESCRIPTION
- Lowered `TAUCUT` to 15 GeV: some taus with pT~18 GeV can be shifted downwards due to TES and EES variations and we don't want to throw them away
- Updated `README.md` to download the ClassicSVfit package from the LLR fork (branch `bbtautau_LegacyRun2`) which already contains the last modifications:
   - Avoid memory leaking
   - Updated rounding function