### PR TITLE
MET unclustered uncertainties

### DIFF
--- a/NtupleProducer/plugins/EleFiller.cc
+++ b/NtupleProducer/plugins/EleFiller.cc
@@ -22,7 +22,7 @@
 #include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
- #include "DataFormats/PatCandidates/interface/VIDCutFlowResult.h"
+#include "DataFormats/PatCandidates/interface/VIDCutFlowResult.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "TTree.h"

--- a/NtupleProducer/python/HiggsTauTauProducer_102X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_102X.py
@@ -759,6 +759,8 @@ else:
         process.METSequence += process.fullPatMetSequence
         PFMetName = "slimmedMETs"
         uncorrPFMetTag = cms.InputTag(PFMetName, "", "TEST")
+        unclusterPFMetEnUpTag   = cms.InputTag("patPFMetT1UnclusteredEnUp","","TEST")
+        unclusterPFMetEnDownTag = cms.InputTag("patPFMetT1UnclusteredEnDown","","TEST")
 
     if YEAR == 2017:
         from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
@@ -775,10 +777,22 @@ else:
         process.METSequence += process.fullPatMetSequenceModifiedMET
         PFMetName = "slimmedMETsModifiedMET"
         uncorrPFMetTag = cms.InputTag(PFMetName, "", "TEST")
-	
+        unclusterPFMetEnUpTag   = cms.InputTag("patPFMetT1UnclusteredEnUpModifiedMET","","TEST")
+        unclusterPFMetEnDownTag = cms.InputTag("patPFMetT1UnclusteredEnDownModifiedMET","","TEST")
+
     if YEAR == 2018:
+        from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+        runMetCorAndUncFromMiniAOD(
+                process,
+                isData = (not IsMC)
+        )
+
+        process.METSequence += process.fullPatMetSequence
+
         PFMetName = "slimmedMETs"
         uncorrPFMetTag = cms.InputTag(PFMetName)
+        unclusterPFMetEnUpTag   = cms.InputTag("patPFMetT1UnclusteredEnUp","","TEST")
+        unclusterPFMetEnDownTag = cms.InputTag("patPFMetT1UnclusteredEnDown","","TEST")
 
 
     # patch to get a standalone MET significance collection
@@ -986,6 +1000,8 @@ if USE_NOHFMET:
 else:
     # MET corrected for central TES and EES shifts of the taus
     process.HTauTauTree.metCollection = srcMETTag
+    process.HTauTauTree.metUnclEnUp   = unclusterPFMetEnUpTag
+    process.HTauTauTree.metUnclEnDown = unclusterPFMetEnDownTag
 
 if YEAR == 2016 or YEAR == 2017:
     process.HTauTauTree.JECset = cms.untracked.string("patJetCorrFactorsTransientCorrectedUpdatedJEC")

--- a/README.md
+++ b/README.md
@@ -389,8 +389,8 @@ cmsenv
 
 git cms-init
 
-# MVA EleID Fall 2018
-git cms-merge-topic cms-egamma:EgammaPostRecoTools  #if you want the V2 IDs, otherwise skip
+# MVA EleID Fall 2018 - if you want the V2 IDs, otherwise skip
+git cms-merge-topic cms-egamma:EgammaPostRecoTools
 
 # PU jet ID
 git cms-addpkg RecoJets/JetProducers
@@ -405,7 +405,7 @@ git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/Recoil
 # LLRHiggsTauTau framework
 git clone git@github.com:LLRCMS/LLRHiggsTauTau.git
 cd LLRHiggsTauTau
-git checkout 102X_HH
+git checkout 102X_HH_systematics
 cd -
 
 git clone -n https://github.com/latinos/UserCode-sixie-Muon-MuonAnalysisTools Muon/MuonAnalysisTools


### PR DESCRIPTION
Adding MET unclustered uncertainties from https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETRun2Corrections#Uncertainty_related_to_Uncluster

Four branches are added: MET magnitude and phi for the up and down variations of the met shifted due to unclustered energy