### PR TITLE
new trigger paths for all years

### DIFF
--- a/NtupleProducer/python/triggers_102X.py
+++ b/NtupleProducer/python/triggers_102X.py
@@ -223,6 +223,170 @@ HLTLIST = cms.VPSet(
         leg2 = cms.int32(15)
         ),
 	
+## === Additional triggers - Valeria study 04/02/2022 (https://indico.cern.ch/event/1124716/contributions/4721294/attachments/2384605/4075311/HH_bbTauTau_DAmante_04Feb.pdf)
+
+    cms.PSet (
+        HLT = cms.string("HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_Ele32_WPTight_Gsf_L1DoubleEG_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+
+    cms.PSet (
+        HLT = cms.string("HLT_Mu50_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_TkMu100_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_OldMu100_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_Mu17_Photon30_IsoCaloId_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMu4_Mass3p8_DZ_PFHT350_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_DoubleMu3_DCA_PFMET50_PFMHT60_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+
+    cms.PSet (
+        HLT = cms.string("HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+    cms.PSet (
+        HLT = cms.string("HLT_Photon35_TwoProngs35_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
 ## Monitoring triggers for 2018 data taking -- Filters should be checked
 #    cms.PSet (
 #        HLT = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTauHPS35_Trk1_eta2p1_Reg_CrossL1_v"),
@@ -401,16 +565,6 @@ HLTLIST = cms.VPSet(
         ),
      )
 
-## === To study -- paths from valeria's studies
-
-#HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4
-#HLT_PFMET120_PFMHT120_IDTight
-#HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5
-#HLT_RsqMR300_Rsq0p09_MR200
-#HLT_Mu50
-#HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59
-#HLT_Photon35_TwoProngs35
-#HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1
 
 #now I create the trigger list for HLTconfig
 for i in range(len(HLTLIST)):

--- a/NtupleProducer/python/triggers_80X.py
+++ b/NtupleProducer/python/triggers_80X.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v 
+## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v
 ## do not remove any other part of path name or the check will give meaningless results!
 
 ## leg numbering: write the object type the two legs refer to
@@ -361,7 +361,7 @@ HLTLIST = cms.VPSet(
          leg1 = cms.int32(13),
          leg2 = cms.int32(11)
          ),
-### === mu mu triggers 
+### === mu mu triggers
 ### FIXME!! MuMu and EleEle paths have not been checked in 80X and filter names are dummy
     cms.PSet (
         HLT = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v"),
@@ -390,7 +390,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(13),
         leg2 = cms.int32(13)
         ),
-### === ele ele triggers 
+### === ele ele triggers
     cms.PSet (
         HLT = cms.string("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
         path1 = cms.vstring (""),
@@ -408,7 +408,7 @@ HLTLIST = cms.VPSet(
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(11)
-        ),    
+        ),
     cms.PSet (
         HLT = cms.string("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v"),
         path1 = cms.vstring (""),
@@ -418,7 +418,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(13),
         leg2 = cms.int32(13)
         ),
-### === 3 lepton triggers 
+### === 3 lepton triggers
     cms.PSet (
         HLT = cms.string("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v"),
         path1 = cms.vstring (""),
@@ -437,6 +437,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(11),
         leg2 = cms.int32(11)
         ),
+
 ### === single tau triggers
     cms.PSet (
         HLT = cms.string("HLT_VLooseIsoPFTau140_Trk50_eta2p1_v"),
@@ -447,7 +448,85 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
         ),
-    )
+    cms.PSet (
+        HLT = cms.string("HLT_VLooseIsoPFTau120_Trk50_eta2p1_v"),
+        path1 = cms.vstring ("hltPFTau120TrackPt50LooseAbsOrRelVLooseIso"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+
+### === MET triggers
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu100_PFMHTNoMu100_IDTight_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+# === tau+MET
+    cms.PSet (
+        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_v"),
+        path1 = cms.vstring ("hltPFTau50TrackPt30LooseAbsOrRelIso"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+    cms.PSet (
+        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET90_v"),
+        path1 = cms.vstring ("hltPFTau50TrackPt30LooseAbsOrRelIso"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+    cms.PSet (
+        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET110_v"),
+        path1 = cms.vstring ("hltPFTau50TrackPt30LooseAbsOrRelIso"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+    cms.PSet (
+        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v"),
+        path1 = cms.vstring ("hltPFTau50TrackPt30LooseAbsOrRelIso"),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+)
+
+
+
 
 #now I create the trigger list for HLTconfig
 for i in range(len(HLTLIST)):

--- a/NtupleProducer/python/triggers_80X.py
+++ b/NtupleProducer/python/triggers_80X.py
@@ -448,6 +448,13 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
         ),
+    cms.PSet ( # match flag?
+        HLT = cms.string("HLT_VLooseIsoPFTau120_Trk50_eta2p1_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
 
 ### === MET triggers
     cms.PSet (
@@ -511,21 +518,6 @@ HLTLIST = cms.VPSet(
     ),
     cms.PSet (
         HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-# === single Tau (matching flags?)
-    cms.PSet (
-        HLT = cms.string("HLT_VLooseIsoPFTau120_Trk50_eta2p1_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-    cms.PSet (
-        HLT = cms.string("HLT_VLooseIsoPFTau140_Trk50_eta2p1_v"),
         path1 = cms.vstring (""),
         path2 = cms.vstring (""),
         leg1 = cms.int32(15),

--- a/NtupleProducer/python/triggers_80X.py
+++ b/NtupleProducer/python/triggers_80X.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v
+## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v 
 ## do not remove any other part of path name or the check will give meaningless results!
 
 ## leg numbering: write the object type the two legs refer to
@@ -361,7 +361,7 @@ HLTLIST = cms.VPSet(
          leg1 = cms.int32(13),
          leg2 = cms.int32(11)
          ),
-### === mu mu triggers
+### === mu mu triggers 
 ### FIXME!! MuMu and EleEle paths have not been checked in 80X and filter names are dummy
     cms.PSet (
         HLT = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v"),
@@ -390,7 +390,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(13),
         leg2 = cms.int32(13)
         ),
-### === ele ele triggers
+### === ele ele triggers 
     cms.PSet (
         HLT = cms.string("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
         path1 = cms.vstring (""),
@@ -408,7 +408,7 @@ HLTLIST = cms.VPSet(
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(11)
-        ),
+        ),    
     cms.PSet (
         HLT = cms.string("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v"),
         path1 = cms.vstring (""),
@@ -418,7 +418,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(13),
         leg2 = cms.int32(13)
         ),
-### === 3 lepton triggers
+### === 3 lepton triggers 
     cms.PSet (
         HLT = cms.string("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v"),
         path1 = cms.vstring (""),
@@ -437,7 +437,6 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(11),
         leg2 = cms.int32(11)
         ),
-
 ### === single tau triggers
     cms.PSet (
         HLT = cms.string("HLT_VLooseIsoPFTau140_Trk50_eta2p1_v"),
@@ -448,85 +447,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
         ),
-    cms.PSet ( # match flag?
-        HLT = cms.string("HLT_VLooseIsoPFTau120_Trk50_eta2p1_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-
-### === MET triggers
-    cms.PSet (
-        HLT = cms.string("HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        path3 = cms.vstring (""),
-        path4 = cms.vstring (""),
-        leg1 = cms.int32(999),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_PFMETNoMu100_PFMHTNoMu100_IDTight_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        path3 = cms.vstring (""),
-        path4 = cms.vstring (""),
-        leg1 = cms.int32(999),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        path3 = cms.vstring (""),
-        path4 = cms.vstring (""),
-        leg1 = cms.int32(999),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        path3 = cms.vstring (""),
-        path4 = cms.vstring (""),
-        leg1 = cms.int32(999),
-        leg2 = cms.int32(999)
-        ),
-
-# === tau+MET (matching flags?)
-    cms.PSet (
-        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-    cms.PSet (
-        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET90_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-    cms.PSet (
-        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET110_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-    cms.PSet (
-        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-)
-
-
-
+    )
 
 #now I create the trigger list for HLTconfig
 for i in range(len(HLTLIST)):

--- a/NtupleProducer/python/triggers_80X.py
+++ b/NtupleProducer/python/triggers_80X.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v 
+## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v
 ## do not remove any other part of path name or the check will give meaningless results!
 
 ## leg numbering: write the object type the two legs refer to
@@ -361,7 +361,7 @@ HLTLIST = cms.VPSet(
          leg1 = cms.int32(13),
          leg2 = cms.int32(11)
          ),
-### === mu mu triggers 
+### === mu mu triggers
 ### FIXME!! MuMu and EleEle paths have not been checked in 80X and filter names are dummy
     cms.PSet (
         HLT = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v"),
@@ -390,7 +390,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(13),
         leg2 = cms.int32(13)
         ),
-### === ele ele triggers 
+### === ele ele triggers
     cms.PSet (
         HLT = cms.string("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
         path1 = cms.vstring (""),
@@ -408,7 +408,7 @@ HLTLIST = cms.VPSet(
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(11)
-        ),    
+        ),
     cms.PSet (
         HLT = cms.string("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v"),
         path1 = cms.vstring (""),
@@ -418,7 +418,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(13),
         leg2 = cms.int32(13)
         ),
-### === 3 lepton triggers 
+### === 3 lepton triggers
     cms.PSet (
         HLT = cms.string("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v"),
         path1 = cms.vstring (""),
@@ -437,6 +437,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(11),
         leg2 = cms.int32(11)
         ),
+
 ### === single tau triggers
     cms.PSet (
         HLT = cms.string("HLT_VLooseIsoPFTau140_Trk50_eta2p1_v"),
@@ -447,7 +448,93 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
         ),
-    )
+
+### === MET triggers
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu100_PFMHTNoMu100_IDTight_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        path3 = cms.vstring (""),
+        path4 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999)
+        ),
+
+# === tau+MET (matching flags?)
+    cms.PSet (
+        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+    cms.PSet (
+        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET90_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+    cms.PSet (
+        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET110_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+    cms.PSet (
+        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+# === single Tau (matching flags?)
+    cms.PSet (
+        HLT = cms.string("HLT_VLooseIsoPFTau120_Trk50_eta2p1_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+    cms.PSet (
+        HLT = cms.string("HLT_VLooseIsoPFTau140_Trk50_eta2p1_v"),
+        path1 = cms.vstring (""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(15),
+        leg2 = cms.int32(999)
+    ),
+)
+
+
+
 
 #now I create the trigger list for HLTconfig
 for i in range(len(HLTLIST)):

--- a/NtupleProducer/python/triggers_80X.py
+++ b/NtupleProducer/python/triggers_80X.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v
+## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v 
 ## do not remove any other part of path name or the check will give meaningless results!
 
 ## leg numbering: write the object type the two legs refer to
@@ -361,7 +361,7 @@ HLTLIST = cms.VPSet(
          leg1 = cms.int32(13),
          leg2 = cms.int32(11)
          ),
-### === mu mu triggers
+### === mu mu triggers 
 ### FIXME!! MuMu and EleEle paths have not been checked in 80X and filter names are dummy
     cms.PSet (
         HLT = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v"),
@@ -390,7 +390,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(13),
         leg2 = cms.int32(13)
         ),
-### === ele ele triggers
+### === ele ele triggers 
     cms.PSet (
         HLT = cms.string("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
         path1 = cms.vstring (""),
@@ -408,7 +408,7 @@ HLTLIST = cms.VPSet(
         path4 = cms.vstring (""),
         leg1 = cms.int32(11),
         leg2 = cms.int32(11)
-        ),
+        ),    
     cms.PSet (
         HLT = cms.string("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v"),
         path1 = cms.vstring (""),
@@ -418,7 +418,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(13),
         leg2 = cms.int32(13)
         ),
-### === 3 lepton triggers
+### === 3 lepton triggers 
     cms.PSet (
         HLT = cms.string("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v"),
         path1 = cms.vstring (""),
@@ -437,7 +437,6 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(11),
         leg2 = cms.int32(11)
         ),
-
 ### === single tau triggers
     cms.PSet (
         HLT = cms.string("HLT_VLooseIsoPFTau140_Trk50_eta2p1_v"),
@@ -448,85 +447,7 @@ HLTLIST = cms.VPSet(
         leg1 = cms.int32(15),
         leg2 = cms.int32(999)
         ),
-    cms.PSet (
-        HLT = cms.string("HLT_VLooseIsoPFTau120_Trk50_eta2p1_v"),
-        path1 = cms.vstring ("hltPFTau120TrackPt50LooseAbsOrRelVLooseIso"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-
-### === MET triggers
-    cms.PSet (
-        HLT = cms.string("HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        path3 = cms.vstring (""),
-        path4 = cms.vstring (""),
-        leg1 = cms.int32(999),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_PFMETNoMu100_PFMHTNoMu100_IDTight_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        path3 = cms.vstring (""),
-        path4 = cms.vstring (""),
-        leg1 = cms.int32(999),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        path3 = cms.vstring (""),
-        path4 = cms.vstring (""),
-        leg1 = cms.int32(999),
-        leg2 = cms.int32(999)
-        ),
-    cms.PSet (
-        HLT = cms.string("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v"),
-        path1 = cms.vstring (""),
-        path2 = cms.vstring (""),
-        path3 = cms.vstring (""),
-        path4 = cms.vstring (""),
-        leg1 = cms.int32(999),
-        leg2 = cms.int32(999)
-        ),
-
-# === tau+MET
-    cms.PSet (
-        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_v"),
-        path1 = cms.vstring ("hltPFTau50TrackPt30LooseAbsOrRelIso"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-    cms.PSet (
-        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET90_v"),
-        path1 = cms.vstring ("hltPFTau50TrackPt30LooseAbsOrRelIso"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-    cms.PSet (
-        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET110_v"),
-        path1 = cms.vstring ("hltPFTau50TrackPt30LooseAbsOrRelIso"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-    cms.PSet (
-        HLT = cms.string("HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v"),
-        path1 = cms.vstring ("hltPFTau50TrackPt30LooseAbsOrRelIso"),
-        path2 = cms.vstring (""),
-        leg1 = cms.int32(15),
-        leg2 = cms.int32(999)
-    ),
-)
-
-
-
+    )
 
 #now I create the trigger list for HLTconfig
 for i in range(len(HLTLIST)):

--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v 
+## TRIGGER VERSIONING: insert paths without the explicit version number, e.g. HLT_anything_v
 ## do not remove any other part of path name or the check will give meaningless results!
 
 ## leg numbering: write the object type the two legs refer to
@@ -450,7 +450,7 @@ HLTLIST = cms.VPSet(
 #        leg1 = cms.int32(13),
 #        leg2 = cms.int32(13)
 #        ),
-        
+
 ### === 3 lepton triggers  -- TO BE DONE
 #    cms.PSet (
 #        HLT = cms.string("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v"),
@@ -468,7 +468,7 @@ HLTLIST = cms.VPSet(
 #        ),
 ### === single tau triggers - OK
     cms.PSet (
-        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v"),     # Do we need this?? probably not...
+        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v"),
         path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched","hltPFTau180TrackPt50LooseAbsOrRelMediumHighPtRelaxedIsoIso"),
         path2 = cms.vstring (""),
         path3 = cms.vstring (""),
@@ -479,7 +479,7 @@ HLTLIST = cms.VPSet(
         pt2 = cms.double(-999)
         ),
     cms.PSet (
-        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v"), # Do we need this?? probably not...
+        HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v"),
         path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched1Prong","hltPFTau180TrackPt50LooseAbsOrRelMediumHighPtRelaxedIso1Prong"),
         path2 = cms.vstring (""),
         path3 = cms.vstring (""),
@@ -568,6 +568,25 @@ HLTLIST = cms.VPSet(
         pt1 = cms.double(55),
         pt2 = cms.double(-999)
         ),
+
+# === MET triggers
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999),
+        ),
+    cms.PSet (
+        HLT = cms.string("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_v"),
+        path1 = cms.vstring ("",""),
+        path2 = cms.vstring (""),
+        leg1 = cms.int32(999),
+        leg2 = cms.int32(999),
+        ),
+
+
+
 ## === 4 jets (for VBF) # FILTERS TO BE FIXED
     #cms.PSet (
     #    HLT = cms.string("HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v7"), #FIXME


### PR DESCRIPTION
For 2018 (`triggers_102X.py`): Including triggers from [Valeria's study](https://indico.cern.ch/event/1124716/contributions/4721294/attachments/2384605/4075311/HH_bbTauTau_DAmante_04Feb.pdf) for 2018 ntuple production.

For 2017 (`triggers_92X.py`): singleTau and Tau+MET triggers were already included. Added only MET triggers to the list.

For 2016 (`triggers_80X.py`): added MET, singleTau, Tau+MET triggers. However I could not find any reference to tau matching flags for these new triggers. I should probably check this with Konstantin