### PR TITLE
Feature/add deep met variables

### DIFF
--- a/NtupleProducer/plugins/DeepMET.cc
+++ b/NtupleProducer/plugins/DeepMET.cc
@@ -1,7 +1,7 @@
 /*
 ** class  : DeepMET
-** author : T. Kramer (UHH)
-** date   : 18 November 2020
+** author : T. Kramer (UHH) 
+** date   : 18 November 2022
 ** brief  : takes in input the met, and produces a pat::METCollection with the pt and phi set to the 
 **          DeepMET values
 */
@@ -15,11 +15,6 @@
 #include <FWCore/Utilities/interface/InputTag.h>
 #include <DataFormats/PatCandidates/interface/CompositeCandidate.h>
 #include <DataFormats/PatCandidates/interface/MET.h>
-// #include <DataFormats/METReco/interface/PFMET.h>
-// #include <DataFormats/METReco/interface/PFMETCollection.h>
-// #include <DataFormats/METReco/interface/CommonMETData.h>
-// #include "TLorentzVector.h"
-// #include <LLRHiggsTauTau/NtupleProducer/interface/DaughterDataHelpers.h>
 #include <DataFormats/Candidate/interface/Candidate.h>
 
 #include <vector>

--- a/NtupleProducer/plugins/DeepMET.cc
+++ b/NtupleProducer/plugins/DeepMET.cc
@@ -1,0 +1,79 @@
+/*
+** class  : DeepMET
+** author : T. Kramer (UHH)
+** date   : 18 November 2020
+** brief  : takes in input the met, and produces a pat::METCollection with the pt and phi set to the 
+**          DeepMET values
+*/
+
+#include <FWCore/Framework/interface/Frameworkfwd.h>
+#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/Framework/interface/ESHandle.h>
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Utilities/interface/InputTag.h>
+#include <DataFormats/PatCandidates/interface/CompositeCandidate.h>
+#include <DataFormats/PatCandidates/interface/MET.h>
+// #include <DataFormats/METReco/interface/PFMET.h>
+// #include <DataFormats/METReco/interface/PFMETCollection.h>
+// #include <DataFormats/METReco/interface/CommonMETData.h>
+// #include "TLorentzVector.h"
+// #include <LLRHiggsTauTau/NtupleProducer/interface/DaughterDataHelpers.h>
+#include <DataFormats/Candidate/interface/Candidate.h>
+
+#include <vector>
+#include <string>
+
+using namespace edm;
+using namespace std;
+using namespace reco;
+
+class DeepMET : public edm::EDProducer {
+    public: 
+        /// Constructor
+        explicit DeepMET(const edm::ParameterSet&);
+        /// Destructor
+        ~DeepMET(){};
+
+    private:
+        virtual void beginJob(){};  
+        virtual void produce(edm::Event&, const edm::EventSetup&);
+        virtual void endJob(){};
+
+        edm::EDGetTokenT<View<pat::MET>> theMETTag;
+        int tune;
+};
+
+DeepMET::DeepMET(const edm::ParameterSet& iConfig) :
+theMETTag(consumes<View<pat::MET>>(iConfig.getParameter<edm::InputTag>("srcMET"))),
+tune(iConfig.getParameter<int>("tune"))
+{
+    produces<pat::METCollection>();
+}
+
+void DeepMET::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+    // Declare ptrs to save MET variations
+    std::unique_ptr<pat::METCollection> out_MET_ptr(new pat::METCollection());
+
+    // Get the MET
+    Handle<View<pat::MET> > METHandle;
+    iEvent.getByToken(theMETTag, METHandle);
+    const pat::MET& patMET = (*METHandle)[0];
+
+    reco::Candidate::PolarLorentzVector deepMETP4(patMET.corPt(pat::MET::METCorrectionLevel(tune)),
+                                                  0.,
+                                                  patMET.corPhi(pat::MET::METCorrectionLevel(tune)), 
+                                                  0.);
+
+    pat::MET deepMET(patMET);
+    deepMET.setP4(deepMETP4);
+
+    out_MET_ptr->push_back(deepMET);
+
+    iEvent.put(std::move(out_MET_ptr));
+}
+
+#include <FWCore/Framework/interface/MakerMacros.h>
+DEFINE_FWK_MODULE(DeepMET);

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -240,6 +240,10 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   edm::EDGetTokenT<pat::METCollection> theShiftedPuppiMetTag;
   edm::EDGetTokenT<math::Error<2>::type> thePuppiMETCovTag;
   edm::EDGetTokenT<double> thePuppiMETSignifTag;
+  edm::EDGetTokenT<pat::METCollection> DeepMETResponseTag;
+  edm::EDGetTokenT<pat::METCollection> DeepMETResolutionTag;
+  edm::EDGetTokenT<pat::METCollection> ShiftedDeepMETResponseTag;
+  edm::EDGetTokenT<pat::METCollection> ShiftedDeepMETResolutionTag;
   edm::EDGetTokenT<edm::View<pat::GenericParticle>> theGenericTag;
   edm::EDGetTokenT<edm::View<reco::GenJet>> theGenJetTag;
   edm::EDGetTokenT<edm::MergeableCounter> theTotTag;
@@ -293,6 +297,14 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   Float_t _PuppiMETCov10;
   Float_t _PuppiMETCov11;
   Float_t _PuppiMETsignif;
+  Float_t _DeepMETresponseTune_pt;
+  Float_t _DeepMETresponseTune_phi;
+  Float_t _DeepMETresolutionTune_pt;
+  Float_t _DeepMETresolutionTune_phi;
+  Float_t _ShiftedDeepMETresponseTune_pt;
+  Float_t _ShiftedDeepMETresponseTune_phi;
+  Float_t _ShiftedDeepMETresolutionTune_pt;
+  Float_t _ShiftedDeepMETresolutionTune_phi;
   Float_t _MC_weight;
   Float_t _aMCatNLOweight;
   Int_t _npv;
@@ -793,6 +805,10 @@ HTauTauNtuplizer::HTauTauNtuplizer(const edm::ParameterSet& pset) : //reweight()
   theShiftedPuppiMetTag(consumes<pat::METCollection>                     (pset.getParameter<edm::InputTag>("metPuppiShiftedCollection"))),
   thePuppiMETCovTag    (consumes<math::Error<2>::type>                   (pset.getParameter<edm::InputTag>("srcPuppiMETCov"))),
   thePuppiMETSignifTag (consumes<double>                                 (pset.getParameter<edm::InputTag>("srcPuppiMETSignificance"))),
+  DeepMETResponseTag   (consumes<pat::METCollection>                     (pset.getParameter<edm::InputTag>("DeepMETResponseTuneCollection"))),
+  DeepMETResolutionTag (consumes<pat::METCollection>                     (pset.getParameter<edm::InputTag>("DeepMETResolutionTuneCollection"))),
+  ShiftedDeepMETResponseTag   (consumes<pat::METCollection>              (pset.getParameter<edm::InputTag>("ShiftedDeepMETResponseTuneCollection"))),
+  ShiftedDeepMETResolutionTag (consumes<pat::METCollection>              (pset.getParameter<edm::InputTag>("ShiftedDeepMETResolutionTuneCollection"))),
   theGenericTag        (consumes<edm::View<pat::GenericParticle>>        (pset.getParameter<edm::InputTag>("genericCollection"))),
   theGenJetTag         (consumes<edm::View<reco::GenJet>>                (pset.getParameter<edm::InputTag>("genjetCollection"))),
   theTotTag            (consumes<edm::MergeableCounter, edm::InLumi>     (pset.getParameter<edm::InputTag>("totCollection"))),
@@ -1170,6 +1186,14 @@ void HTauTauNtuplizer::Initialize(){
   _PuppiMETCov10=0.;
   _PuppiMETCov11=0.;
   _PuppiMETsignif=0.;
+  _DeepMETresponseTune_pt=0;
+  _DeepMETresponseTune_phi=0;
+  _DeepMETresolutionTune_pt=0;
+  _DeepMETresolutionTune_phi=0;
+  _ShiftedDeepMETresponseTune_pt=0;
+  _ShiftedDeepMETresponseTune_phi=0;
+  _ShiftedDeepMETresolutionTune_pt=0;
+  _ShiftedDeepMETresolutionTune_phi=0;
   _MC_weight=0.;
   _npv=0;
   _lheHt=0;
@@ -1334,6 +1358,14 @@ void HTauTauNtuplizer::beginJob(){
   myTree->Branch("PuppiMETCov10",&_PuppiMETCov10,"PuppiMETCov10/F");
   myTree->Branch("PuppiMETCov11",&_PuppiMETCov11,"PuppiMETCov11/F");
   myTree->Branch("PuppiMETsignif", &_PuppiMETsignif, "PuppiMETsignif/F");
+  myTree->Branch("DeepMETresponseTune_pt",&_DeepMETresponseTune_pt,"DeepMETresponseTune_pt/F");
+  myTree->Branch("DeepMETresponseTune_phi",&_DeepMETresponseTune_phi,"DeepMETresponseTune_phi/F");
+  myTree->Branch("DeepMETresolutionTune_pt",&_DeepMETresolutionTune_pt,"DeepMETresolutionTune_pt/F");
+  myTree->Branch("DeepMETresolutionTune_phi",&_DeepMETresolutionTune_phi,"DeepMETresolutionTune_phi/F");
+  myTree->Branch("ShiftedDeepMETresponseTune_pt",&_ShiftedDeepMETresponseTune_pt,"ShiftedDeepMETresponseTune_pt/F");
+  myTree->Branch("ShiftedDeepMETresponseTune_phi",&_ShiftedDeepMETresponseTune_phi,"ShiftedDeepMETresponseTune_phi/F");
+  myTree->Branch("ShiftedDeepMETresolutionTune_pt",&_ShiftedDeepMETresolutionTune_pt,"ShiftedDeepMETresolutionTune_pt/F");
+  myTree->Branch("ShiftedDeepMETresolutionTune_phi",&_ShiftedDeepMETresolutionTune_phi,"ShiftedDeepMETresolutionTune_phi/F");
   myTree->Branch("npv",&_npv,"npv/I");  
   myTree->Branch("npu",&_npu,"npu/F"); 
   //myTree->Branch("PUReweight",&_PUReweight,"PUReweight/F"); //FRA January2019
@@ -1865,6 +1897,10 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
   edm::Handle<pat::METCollection> metPuppiShiftedHandle;
   edm::Handle<math::Error<2>::type> PuppicovHandle;
   edm::Handle<double> PuppiMETsignficanceHandle;
+  edm::Handle<pat::METCollection> DeepMETResponseHandle;
+  edm::Handle<pat::METCollection> DeepMETResolutionHandle;
+  edm::Handle<pat::METCollection> ShiftedDeepMETResponseHandle;
+  edm::Handle<pat::METCollection> ShiftedDeepMETResolutionHandle;
   edm::Handle<GenFilterInfo> embeddingWeightHandle;
   edm::Handle<edm::TriggerResults> triggerResults;
   //edm::Handle<int> NBadMuHandle; //FRA January2019
@@ -1893,7 +1929,11 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
   event.getByToken(thePUPPIMetTag,PUPPImetHandle);
   event.getByToken(theShiftedPuppiMetTag,metPuppiShiftedHandle);
   event.getByToken(thePuppiMETCovTag,PuppicovHandle);
-  event.getByToken(thePuppiMETSignifTag,PuppiMETsignficanceHandle);  
+  event.getByToken(thePuppiMETSignifTag,PuppiMETsignficanceHandle);
+  event.getByToken(DeepMETResponseTag,DeepMETResponseHandle);
+  event.getByToken(DeepMETResolutionTag,DeepMETResolutionHandle);
+  event.getByToken(ShiftedDeepMETResponseTag,ShiftedDeepMETResponseHandle);
+  event.getByToken(ShiftedDeepMETResolutionTag,ShiftedDeepMETResolutionHandle);
   //event.getByToken(theNBadMuTag,NBadMuHandle); //FRA January2019
   event.getByToken(prefweight_token, theprefweight);
   event.getByToken(prefweightup_token, theprefweightup);
@@ -1954,6 +1994,10 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
   const pat::MET &met_er = metERHandle->front();
   const pat::MET &PUPPImet = PUPPImetHandle->front();
   const pat::MET &metPuppiShifted = metPuppiShiftedHandle->front();
+  const pat::MET &DeepMETResponseTune = DeepMETResponseHandle->front();
+  const pat::MET &DeepMETResolutionTune = DeepMETResolutionHandle->front();
+  const pat::MET &ShiftedDeepMETResponseTune = ShiftedDeepMETResponseHandle->front();
+  const pat::MET &ShiftedDeepMETResolutionTune = ShiftedDeepMETResolutionHandle->front();
   const BXVector<l1t::Tau>* L1Tau = L1TauHandle.product();
   const BXVector<l1t::Jet>* L1Jet = L1JetHandle.product();
   //myNtuple->InitializeVariables();
@@ -1982,7 +2026,15 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
   _PuppiMETCov11 = (*PuppicovHandle)(1,1);
   _PuppiMETsignif = (*PuppiMETsignficanceHandle);  
   _PUPPImetShiftedX = metPuppiShifted.px();
-  _PUPPImetShiftedY = metPuppiShifted.py();  
+  _PUPPImetShiftedY = metPuppiShifted.py();
+  _DeepMETresponseTune_pt = DeepMETResponseTune.pt();
+  _DeepMETresponseTune_phi = DeepMETResponseTune.phi();
+  _DeepMETresolutionTune_pt = DeepMETResolutionTune.pt();
+  _DeepMETresolutionTune_phi = DeepMETResolutionTune.phi();
+  _ShiftedDeepMETresponseTune_pt = ShiftedDeepMETResponseTune.pt();
+  _ShiftedDeepMETresponseTune_phi = ShiftedDeepMETResponseTune.phi();
+  _ShiftedDeepMETresolutionTune_pt = ShiftedDeepMETResolutionTune.pt();
+  _ShiftedDeepMETresolutionTune_phi = ShiftedDeepMETResolutionTune.phi();
   //_NBadMu = (*NBadMuHandle); //FRA January2019
   if (theisMC)
   {

--- a/NtupleProducer/python/HiggsTauTauProducer_106X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_106X.py
@@ -594,12 +594,13 @@ else:
     process.METSequence += process.PuppiMETSignificance
     process.METSequence += process.ShiftPuppiMETcentral
 
+    # Add both DeepMET tunes
     for tuneName, tuneIdx in zip(["RawDeepResponseTune", "RawDeepResolutionTune"],[13, 14]):
 
-        # Add DeepMET collection
-        DeepMET = cms.EDProducer ("DeepMET",
+        # Add standalone DeepMET collections
+        DeepMET = cms.EDProducer ("CorrectedMETCollectionProducer",
                                   srcMET = cms.InputTag("slimmedMETs"),
-                                  tune = cms.int32(tuneIdx),
+                                  correctionLevel = cms.int32(tuneIdx),
                                   )
 
         setattr(process, "DeepMET" + tuneName, DeepMET)

--- a/NtupleProducer/python/HiggsTauTauProducer_106X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_106X.py
@@ -594,6 +594,28 @@ else:
     process.METSequence += process.PuppiMETSignificance
     process.METSequence += process.ShiftPuppiMETcentral
 
+    for tuneName, tuneIdx in zip(["RawDeepResponseTune", "RawDeepResolutionTune"],[13, 14]):
+
+        # Add DeepMET collection
+        DeepMET = cms.EDProducer ("DeepMET",
+                                  srcMET = cms.InputTag("slimmedMETs"),
+                                  tune = cms.int32(tuneIdx),
+                                  )
+
+        setattr(process, "DeepMET" + tuneName, DeepMET)
+
+        # Shift DeepMET due to central corrections of TES and EES
+        ShiftDeepMETcentral = cms.EDProducer ("ShiftMETcentral",
+                                              srcMET = cms.InputTag("DeepMET" + tuneName),
+                                              tauUncorrected = cms.InputTag("bareTaus"),
+                                              tauCorrected = cms.InputTag("softTaus"),
+                                              )
+
+        setattr(process, "ShiftDeepMETcentral" + tuneName, ShiftDeepMETcentral)
+
+        process.METSequence += getattr(process, "DeepMET" + tuneName)
+        process.METSequence += getattr(process, "ShiftDeepMETcentral" + tuneName)
+
 ## ----------------------------------------------------------------------
 ## Z-recoil correction
 ## ----------------------------------------------------------------------
@@ -725,6 +747,10 @@ process.HTauTauTree = cms.EDAnalyzer("HTauTauNtuplizer",
                       srcPFMETCov = cms.InputTag("METSignificance", "METCovariance"),
                       srcPFMETSignificance = cms.InputTag("METSignificance", "METSignificance"),
                       metERCollection = uncorrPFMetTag, # save the uncorrected MET (for TES and EES central shifts) just for reference
+                      DeepMETResponseTuneCollection = cms.InputTag("DeepMETRawDeepResponseTune"),
+                      DeepMETResolutionTuneCollection = cms.InputTag("DeepMETRawDeepResolutionTune"),
+                      ShiftedDeepMETResponseTuneCollection = cms.InputTag("ShiftDeepMETcentralRawDeepResponseTune"),
+                      ShiftedDeepMETResolutionTuneCollection = cms.InputTag("ShiftDeepMETcentralRawDeepResolutionTune"),
                       HT = cms.InputTag("externalLHEProducer"),
                       beamSpot = cms.InputTag("offlineBeamSpot"),
                       genLumiHeaderTag = cms.InputTag("generator"),

--- a/NtupleProducer/python/HiggsTauTauProducer_106X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_106X.py
@@ -594,7 +594,8 @@ else:
     process.METSequence += process.PuppiMETSignificance
     process.METSequence += process.ShiftPuppiMETcentral
 
-    # Add both DeepMET tunes
+    # Add both DeepMET tunes from the METCorrectionLevels:
+    # https://github.com/cms-sw/cmssw/blob/ef3151a362db68a97ef10c4ff993af637cd163ef/DataFormats/PatCandidates/interface/MET.h#L173-L190
     for tuneName, tuneIdx in zip(["RawDeepResponseTune", "RawDeepResolutionTune"],[13, 14]):
 
         # Add standalone DeepMET collections


### PR DESCRIPTION
This PR adds a producer for standalone METCollections given a METCorrectionLevel. Using this, METCollections for the two DeepMET tunes (Response and Resolution) present in the UL MiniAODv2 are added in the config. Additional collections to account for the shift by central corrections (TES and EES) to hadronic taus are added analogously to what is already done for the "standard" MET. Finally, the respective pt and phi variables are added to the NTuplizer