### PR TITLE
Update GT for data

### DIFF
--- a/NtupleProducer/python/HiggsTauTauProducer_106X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_106X.py
@@ -82,7 +82,7 @@ if IsMC:
   if YEAR == 2018:
     process.GlobalTag.globaltag = '106X_upgrade2018_realistic_v16_L1v1'  # 2018 MC
 else :
-    process.GlobalTag.globaltag = '106X_dataRun2_v35'                    # Data
+    process.GlobalTag.globaltag = '106X_dataRun2_v37'                    # Data
 
 print "GT: ",process.GlobalTag.globaltag
 


### PR DESCRIPTION
Updates the GlobalTag for data from 106X_dataRun2_v35 to 106X_dataRun2_v37 
(see https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun2LegacyAnalysis)