### PR TITLE
Fixing bug with AK8 PNet ProbQCD variable

### DIFF
--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -2778,7 +2778,7 @@ void HTauTauNtuplizer::FillFatJet(const edm::View<pat::Jet>* fatjets, const edm:
       _ak8jets_particleNetMDJetTags_probQCD.push_back(ijet->bDiscriminator("pfMassDecorrelatedParticleNetJetTags:probQCDbb") +
 						      ijet->bDiscriminator("pfMassDecorrelatedParticleNetJetTags:probQCDb")  +
 						      ijet->bDiscriminator("pfMassDecorrelatedParticleNetJetTags:probQCDcc") +
-						      ijet->bDiscriminator("pfMassDecorrelatedParticleNetJetTags:probQCDbc") +
+						      ijet->bDiscriminator("pfMassDecorrelatedParticleNetJetTags:probQCDc") +
 						      ijet->bDiscriminator("pfMassDecorrelatedParticleNetJetTags:probQCDothers"));
       _ak8jets_particleNetMDJetTags_mass.push_back(ijet->bDiscriminator("pfParticleNetMassRegressionJetTags:mass"));
       // store subjets for soft drop


### PR DESCRIPTION
A typo was introduced in the evaluation of `ak8jets_particleNetMDJetTags_probQCD`. It is now fixed, and the variable shows the expected behaviour.

Before the fix (plot provided by @dzuolo on Mattermost):
![image](https://github.com/LLRCMS/LLRHiggsTauTau/assets/72452043/de784c56-fd00-4cc7-9a14-9a167a2e13c5)

After the fix (here for spin 0 signal with mX=2500 GeV):
![image](https://github.com/LLRCMS/LLRHiggsTauTau/assets/72452043/6a3ec3d4-e494-453d-ac87-0f6de7024b0f)
