### PR TITLE
Remove 2nd SingleTau filter in 2017

### DIFF
--- a/NtupleProducer/python/triggers_92X.py
+++ b/NtupleProducer/python/triggers_92X.py
@@ -469,7 +469,7 @@ HLTLIST = cms.VPSet(
 ### === single tau triggers - OK
     cms.PSet (
         HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v"),
-        path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched","hltPFTau180TrackPt50LooseAbsOrRelMediumHighPtRelaxedIsoIso"),
+        path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched"),
         path2 = cms.vstring (""),
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),
@@ -480,7 +480,7 @@ HLTLIST = cms.VPSet(
         ),
     cms.PSet (
         HLT = cms.string("HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v"),
-        path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched1Prong","hltPFTau180TrackPt50LooseAbsOrRelMediumHighPtRelaxedIso1Prong"),
+        path1 = cms.vstring ("hltSelectedPFTau180MediumChargedIsolationL1HLTMatched1Prong"),
         path2 = cms.vstring (""),
         path3 = cms.vstring (""),
         path4 = cms.vstring (""),


### PR DESCRIPTION
This PR removes the 2nd SingleTau filter that was required in 2017. These filters are checked in a way that requires the same TriggerObject to pass both of these filters which never happens, resulting in not selecting any SingleTau events in 2017. After a discussion with cms-trigger-TAU-conveners it became clear we can remove this 2nd filter