### PR TITLE
Revert postVFP flag change

### DIFF
--- a/NtupleProducer/python/HiggsTauTauProducer_106X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_106X.py
@@ -13,7 +13,7 @@ except NameError:
 try: YEAR
 except NameError:
     YEAR = 2018
-assert YEAR in ("2016", "2017", "2018")
+assert YEAR in (2016, 2017, 2018)
 try: PERIOD
 except:
     PERIOD =""

--- a/NtupleProducer/python/HiggsTauTauProducer_106X.py
+++ b/NtupleProducer/python/HiggsTauTauProducer_106X.py
@@ -13,10 +13,12 @@ except NameError:
 try: YEAR
 except NameError:
     YEAR = 2018
+assert YEAR in ("2016", "2017", "2018")
 try: PERIOD
 except:
     PERIOD =""
 print 'Year+Period:', str(YEAR)+PERIOD
+assert PERIOD in ("", "postVFP")
 try: doCPVariables
 except NameError:
     doCPVariables=True       

--- a/NtupleProducer/test/submitAllDatasetOnCrab_LLR.py
+++ b/NtupleProducer/test/submitAllDatasetOnCrab_LLR.py
@@ -8,61 +8,62 @@ import re
 ###################################################################
 #### Parameters to be changed for each production
 
-YEAR = "16"
-assert YEAR in ("16", "17", "18")
+YEAR = "2016"
+assert YEAR in ("2016", "2017", "2018")
 
 PERIOD = '' # 'APV' # can be left empty if running on 2017 and 2018
-assert PERIOD in ("", "APV")
+assert PERIOD in ("", "postVFP")
 
 PREFIX = "MC"
 assert PREFIX in ("Sig", "MC", "Data")
 TAG = "April2024"
 
-datasetsFile = "datasets_UL" + YEAR + PERIOD + ".txt"
-nolocFile = "datasets_UL" + YEAR + ".noloc.txt"
-tag = PREFIX + "_UL" + YEAR + PERIOD + "_" + TAG
+era = "APV" if PERIOD=="" else ""
+datasetsFile = "datasets_UL" + YEAR[-2:] + era + ".txt"
+nolocFile = "datasets_UL" + YEAR[-2:] + ".noloc.txt"
+tag = PREFIX + "_UL" + YEAR[-2:] + era + "_" + TAG
 
-if YEAR == "16":
+if YEAR == "2016":
     lumiMaskFileName = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt'
 
-elif YEAR == "17":
+elif YEAR == "2017":
     lumiMaskFileName = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt'
 
-elif YEAR == "18":
+elif YEAR == "2018":
     lumiMaskFileName = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/Legacy_2018/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt'
     
 # /!\ Be sure that the IsMC flag in analyzer_LLR.py matches this one!
 isMC = True if PREFIX in ("Sig", "MC") else False 
 
 PROCESS = [
-    "BACKGROUNDS_TT_20" + YEAR + PERIOD,
-    "BACKGROUNDS_WJETS_20" + YEAR + PERIOD,
-    "BACKGROUNDS_DY_NLO_20" + YEAR + PERIOD,
-    #"BACKGROUNDS_DY_NLO_PTSLICED_20" + YEAR + PERIOD,
-    "BACKGROUNDS_DY_20" + YEAR + PERIOD,
-    "BACKGROUNDS_VV_20" + YEAR + PERIOD,
-    "BACKGROUNDS_VVV_20" + YEAR + PERIOD,
-    "BACKGROUNDS_ST_20" + YEAR + PERIOD,
-    "BACKGROUNDS_EWK_20" + YEAR + PERIOD,
-    "BACKGROUNDS_H_20" + YEAR + PERIOD,
-    "BACKGROUNDS_TTX_20" + YEAR + PERIOD,
-    "BACKGROUNDS_TTVH_20" + YEAR + PERIOD,
-    #"BACKGROUNDS_DY_QQ_HTSLICED_20" + YEAR + PERIOD
-    "BACKGROUNDS_HH_20" + YEAR + PERIOD
-    # "BACKGROUNDS_DY_LM_20" + YEAR + PERIOD
+    "BACKGROUNDS_TT_" + YEAR + era,
+    "BACKGROUNDS_WJETS_" + YEAR + era,
+    "BACKGROUNDS_DY_NLO_" + YEAR + era,
+    #"BACKGROUNDS_DY_NLO_PTSLICED_" + YEAR + era,
+    "BACKGROUNDS_DY_" + YEAR + era,
+    "BACKGROUNDS_VV_" + YEAR + era,
+    "BACKGROUNDS_VVV_" + YEAR + era,
+    "BACKGROUNDS_ST_" + YEAR + era,
+    "BACKGROUNDS_EWK_" + YEAR + era,
+    "BACKGROUNDS_H_" + YEAR + era,
+    "BACKGROUNDS_TTX_" + YEAR + era,
+    "BACKGROUNDS_TTVH_" + YEAR + era,
+    #"BACKGROUNDS_DY_QQ_HTSLICED_" + YEAR + era
+    "BACKGROUNDS_HH_" + YEAR + era
+    # "BACKGROUNDS_DY_LM_" + YEAR + era
 
-    # "SIGNALS_GF_SPIN0_20" + YEAR + PERIOD,
-    # "SIGNALS_GF_SPIN2_20" + YEAR + PERIOD,
-    # "SIGNALS_HY_20" + YEAR + PERIOD,
+    # "SIGNALS_GF_SPIN0_" + YEAR + era,
+    # "SIGNALS_GF_SPIN2_" + YEAR + era,
+    # "SIGNALS_HY_" + YEAR + era,
 ]
 
 if not isMC:
     PROCESS = [
-        "DATA_TAU_20" + YEAR + PERIOD,
-        "DATA_ELE_20" + YEAR + PERIOD,
-        "DATA_MU_20" + YEAR + PERIOD,
-        "DATA_MET_20" + YEAR + PERIOD,
-        "DATA_DOUBLEMU_20" + YEAR + PERIOD
+        "DATA_TAU_" + YEAR + era,
+        "DATA_ELE_" + YEAR + era,
+        "DATA_MU_" + YEAR + era,
+        "DATA_MET_" + YEAR + era,
+        "DATA_DOUBLEMU_" + YEAR + era
     ]
 
 FastJobs = False # controls number of jobs - true if skipping SVfit, false if computing it (jobs will be smaller)

--- a/NtupleProducer/test/submitAllDatasetOnCrab_LLR.py
+++ b/NtupleProducer/test/submitAllDatasetOnCrab_LLR.py
@@ -182,7 +182,7 @@ for dtset in dtsetToLaunch:
                         " General.requestName=%s" % (shortName + "_" + str(counter)),
                         " General.workArea=%s" % crabJobsFolder,
                         " Data.inputDataset=%s" % dtset,
-                        " Data.outLFNDirBase=/store/user/bfontana/HHNtuples_res/UL" + str(YEAR) + "/%s/%s" % (tag, str(counter)+"_"+dtsetNames),
+                        " Data.outLFNDirBase=/store/user/bfontana/HHNtuples_res/UL" + str(YEAR) + period16 + "/%s/%s" % (tag, str(counter)+"_"+dtsetNames),
                         " Data.outputDatasetTag=%s" % (shortName + "_" + tag + "_" + str(counter)),
                         " Data.splitting='Automatic'",
                         " Data.splitting='FileBased'",

--- a/NtupleProducer/test/submitAllDatasetOnCrab_LLR.py
+++ b/NtupleProducer/test/submitAllDatasetOnCrab_LLR.py
@@ -11,17 +11,17 @@ import re
 YEAR = 2016
 assert YEAR in (2016, 2017, 2018)
 
-PERIOD = '' # 'APV' # can be left empty if running on 2017 and 2018
+PERIOD = "" # 'postVFP' # can be left empty if running on 2017 and 2018
 assert PERIOD in ("", "postVFP")
 
 PREFIX = "MC"
 assert PREFIX in ("Sig", "MC", "Data")
 TAG = "April2024"
 
-era = "APV" if PERIOD=="" else ""
-datasetsFile = "datasets_UL" + str(YEAR[-2:]) + era + ".txt"
+period16 = "APV" if (PERIOD=="" and YEAR==2016) else ""
+datasetsFile = "datasets_UL" + str(YEAR[-2:]) + period16 + ".txt"
 nolocFile = "datasets_UL" + str(YEAR[-2:]) + ".noloc.txt"
-tag = PREFIX + "_UL" + str(YEAR[-2:]) + era + "_" + TAG
+tag = PREFIX + "_UL" + str(YEAR[-2:]) + period16 + "_" + TAG
 
 if YEAR == 2016:
     lumiMaskFileName = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt'
@@ -36,34 +36,34 @@ elif YEAR == 2018:
 isMC = True if PREFIX in ("Sig", "MC") else False 
 
 PROCESS = [
-    "BACKGROUNDS_TT_" + str(YEAR) + era,
-    "BACKGROUNDS_WJETS_" + str(YEAR) + era,
-    "BACKGROUNDS_DY_NLO_" + str(YEAR) + era,
-    #"BACKGROUNDS_DY_NLO_PTSLICED_" + str(YEAR) + era,
-    "BACKGROUNDS_DY_" + str(YEAR) + era,
-    "BACKGROUNDS_VV_" + str(YEAR) + era,
-    "BACKGROUNDS_VVV_" + str(YEAR) + era,
-    "BACKGROUNDS_ST_" + str(YEAR) + era,
-    "BACKGROUNDS_EWK_" + str(YEAR) + era,
-    "BACKGROUNDS_H_" + str(YEAR) + era,
-    "BACKGROUNDS_TTX_" + str(YEAR) + era,
-    "BACKGROUNDS_TTVH_" + str(YEAR) + era,
-    #"BACKGROUNDS_DY_QQ_HTSLICED_" + str(YEAR) + era
-    "BACKGROUNDS_HH_" + str(YEAR) + era
-    # "BACKGROUNDS_DY_LM_" + str(YEAR) + era
+    "BACKGROUNDS_TT_" + str(YEAR) + period16,
+    "BACKGROUNDS_WJETS_" + str(YEAR) + period16,
+    "BACKGROUNDS_DY_NLO_" + str(YEAR) + period16,
+    #"BACKGROUNDS_DY_NLO_PTSLICED_" + str(YEAR) + period16,
+    "BACKGROUNDS_DY_" + str(YEAR) + period16,
+    "BACKGROUNDS_VV_" + str(YEAR) + period16,
+    "BACKGROUNDS_VVV_" + str(YEAR) + period16,
+    "BACKGROUNDS_ST_" + str(YEAR) + period16,
+    "BACKGROUNDS_EWK_" + str(YEAR) + period16,
+    "BACKGROUNDS_H_" + str(YEAR) + period16,
+    "BACKGROUNDS_TTX_" + str(YEAR) + period16,
+    "BACKGROUNDS_TTVH_" + str(YEAR) + period16,
+    #"BACKGROUNDS_DY_QQ_HTSLICED_" + str(YEAR) + period16
+    "BACKGROUNDS_HH_" + str(YEAR) + period16
+    # "BACKGROUNDS_DY_LM_" + str(YEAR) + period16
 
-    # "SIGNALS_GF_SPIN0_" + str(YEAR) + era,
-    # "SIGNALS_GF_SPIN2_" + str(YEAR) + era,
-    # "SIGNALS_HY_" + str(YEAR) + era,
+    # "SIGNALS_GF_SPIN0_" + str(YEAR) + period16,
+    # "SIGNALS_GF_SPIN2_" + str(YEAR) + period16,
+    # "SIGNALS_HY_" + str(YEAR) + period16,
 ]
 
 if not isMC:
     PROCESS = [
-        "DATA_TAU_" + str(YEAR) + era,
-        "DATA_ELE_" + str(YEAR) + era,
-        "DATA_MU_" + str(YEAR) + era,
-        "DATA_MET_" + str(YEAR) + era,
-        "DATA_DOUBLEMU_" + str(YEAR) + era
+        "DATA_TAU_" + str(YEAR) + period16,
+        "DATA_ELE_" + str(YEAR) + period16,
+        "DATA_MU_" + str(YEAR) + period16,
+        "DATA_MET_" + str(YEAR) + period16,
+        "DATA_DOUBLEMU_" + str(YEAR) + period16
     ]
 
 FastJobs = False # controls number of jobs - true if skipping SVfit, false if computing it (jobs will be smaller)

--- a/NtupleProducer/test/submitAllDatasetOnCrab_LLR.py
+++ b/NtupleProducer/test/submitAllDatasetOnCrab_LLR.py
@@ -8,8 +8,8 @@ import re
 ###################################################################
 #### Parameters to be changed for each production
 
-YEAR = "2016"
-assert YEAR in ("2016", "2017", "2018")
+YEAR = 2016
+assert YEAR in (2016, 2017, 2018)
 
 PERIOD = '' # 'APV' # can be left empty if running on 2017 and 2018
 assert PERIOD in ("", "postVFP")
@@ -19,51 +19,51 @@ assert PREFIX in ("Sig", "MC", "Data")
 TAG = "April2024"
 
 era = "APV" if PERIOD=="" else ""
-datasetsFile = "datasets_UL" + YEAR[-2:] + era + ".txt"
-nolocFile = "datasets_UL" + YEAR[-2:] + ".noloc.txt"
-tag = PREFIX + "_UL" + YEAR[-2:] + era + "_" + TAG
+datasetsFile = "datasets_UL" + str(YEAR[-2:]) + era + ".txt"
+nolocFile = "datasets_UL" + str(YEAR[-2:]) + ".noloc.txt"
+tag = PREFIX + "_UL" + str(YEAR[-2:]) + era + "_" + TAG
 
-if YEAR == "2016":
+if YEAR == 2016:
     lumiMaskFileName = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt'
 
-elif YEAR == "2017":
+elif YEAR == 2017:
     lumiMaskFileName = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt'
 
-elif YEAR == "2018":
+elif YEAR == 2018:
     lumiMaskFileName = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/Legacy_2018/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt'
     
 # /!\ Be sure that the IsMC flag in analyzer_LLR.py matches this one!
 isMC = True if PREFIX in ("Sig", "MC") else False 
 
 PROCESS = [
-    "BACKGROUNDS_TT_" + YEAR + era,
-    "BACKGROUNDS_WJETS_" + YEAR + era,
-    "BACKGROUNDS_DY_NLO_" + YEAR + era,
-    #"BACKGROUNDS_DY_NLO_PTSLICED_" + YEAR + era,
-    "BACKGROUNDS_DY_" + YEAR + era,
-    "BACKGROUNDS_VV_" + YEAR + era,
-    "BACKGROUNDS_VVV_" + YEAR + era,
-    "BACKGROUNDS_ST_" + YEAR + era,
-    "BACKGROUNDS_EWK_" + YEAR + era,
-    "BACKGROUNDS_H_" + YEAR + era,
-    "BACKGROUNDS_TTX_" + YEAR + era,
-    "BACKGROUNDS_TTVH_" + YEAR + era,
-    #"BACKGROUNDS_DY_QQ_HTSLICED_" + YEAR + era
-    "BACKGROUNDS_HH_" + YEAR + era
-    # "BACKGROUNDS_DY_LM_" + YEAR + era
+    "BACKGROUNDS_TT_" + str(YEAR) + era,
+    "BACKGROUNDS_WJETS_" + str(YEAR) + era,
+    "BACKGROUNDS_DY_NLO_" + str(YEAR) + era,
+    #"BACKGROUNDS_DY_NLO_PTSLICED_" + str(YEAR) + era,
+    "BACKGROUNDS_DY_" + str(YEAR) + era,
+    "BACKGROUNDS_VV_" + str(YEAR) + era,
+    "BACKGROUNDS_VVV_" + str(YEAR) + era,
+    "BACKGROUNDS_ST_" + str(YEAR) + era,
+    "BACKGROUNDS_EWK_" + str(YEAR) + era,
+    "BACKGROUNDS_H_" + str(YEAR) + era,
+    "BACKGROUNDS_TTX_" + str(YEAR) + era,
+    "BACKGROUNDS_TTVH_" + str(YEAR) + era,
+    #"BACKGROUNDS_DY_QQ_HTSLICED_" + str(YEAR) + era
+    "BACKGROUNDS_HH_" + str(YEAR) + era
+    # "BACKGROUNDS_DY_LM_" + str(YEAR) + era
 
-    # "SIGNALS_GF_SPIN0_" + YEAR + era,
-    # "SIGNALS_GF_SPIN2_" + YEAR + era,
-    # "SIGNALS_HY_" + YEAR + era,
+    # "SIGNALS_GF_SPIN0_" + str(YEAR) + era,
+    # "SIGNALS_GF_SPIN2_" + str(YEAR) + era,
+    # "SIGNALS_HY_" + str(YEAR) + era,
 ]
 
 if not isMC:
     PROCESS = [
-        "DATA_TAU_" + YEAR + era,
-        "DATA_ELE_" + YEAR + era,
-        "DATA_MU_" + YEAR + era,
-        "DATA_MET_" + YEAR + era,
-        "DATA_DOUBLEMU_" + YEAR + era
+        "DATA_TAU_" + str(YEAR) + era,
+        "DATA_ELE_" + str(YEAR) + era,
+        "DATA_MU_" + str(YEAR) + era,
+        "DATA_MET_" + str(YEAR) + era,
+        "DATA_DOUBLEMU_" + str(YEAR) + era
     ]
 
 FastJobs = False # controls number of jobs - true if skipping SVfit, false if computing it (jobs will be smaller)
@@ -182,7 +182,7 @@ for dtset in dtsetToLaunch:
                         " General.requestName=%s" % (shortName + "_" + str(counter)),
                         " General.workArea=%s" % crabJobsFolder,
                         " Data.inputDataset=%s" % dtset,
-                        " Data.outLFNDirBase=/store/user/bfontana/HHNtuples_res/UL" + YEAR + "/%s/%s" % (tag, str(counter)+"_"+dtsetNames),
+                        " Data.outLFNDirBase=/store/user/bfontana/HHNtuples_res/UL" + str(YEAR) + "/%s/%s" % (tag, str(counter)+"_"+dtsetNames),
                         " Data.outputDatasetTag=%s" % (shortName + "_" + tag + "_" + str(counter)),
                         " Data.splitting='Automatic'",
                         " Data.splitting='FileBased'",


### PR DESCRIPTION
The code depends on multiple places of the hard-coded "postVFP" value. I've thus reverted the change introduced in #167, removing the option "APV".
For reference, preVFP=HIPM=APV.

The bug caused 2016 (post-VFP) samples to be produced with "pre-VFP" options. Big ntuples will have to be rerun.